### PR TITLE
Fix model check for API Keys in new directory structure

### DIFF
--- a/internal/provider/bun.go
+++ b/internal/provider/bun.go
@@ -95,19 +95,9 @@ func (p *BunProvider) ConfigureDeploymentConfig(config *project.DeploymentConfig
 }
 
 func (p *BunProvider) DeployPreflightCheck(logger logger.Logger, data DeployPreflightCheckData) error {
-	buf, _ := os.ReadFile(filepath.Join(data.Dir, "index.ts"))
-	str := string(buf)
-	if openAICheck.MatchString(str) {
-		tok := openAICheck.FindStringSubmatch(str)
-		if len(tok) != 2 {
-			return fmt.Errorf("failed to find openai token in index.ts")
-		}
-		model := tok[1]
-		if err := validateModelSecretSet(logger, data, model); err != nil {
-			return fmt.Errorf("failed to validate model secret: %w", err)
-		}
+	if err := detectModelTokens(logger, data, data.Dir); err != nil {
+		return fmt.Errorf("failed to detect model tokens: %w", err)
 	}
-
 	if err := BundleJS(logger, data.Dir, "bun", true); err != nil {
 		return fmt.Errorf("failed to bundle JS: %w", err)
 	}

--- a/internal/provider/node.go
+++ b/internal/provider/node.go
@@ -95,19 +95,9 @@ func (p *NodeJSProvider) ConfigureDeploymentConfig(config *project.DeploymentCon
 var openAICheck = regexp.MustCompile(`openai\("([\w-]+)"\)`) // TODO: need to expand this
 
 func (p *NodeJSProvider) DeployPreflightCheck(logger logger.Logger, data DeployPreflightCheckData) error {
-	buf, _ := os.ReadFile(filepath.Join(data.Dir, "index.ts"))
-	str := string(buf)
-	if openAICheck.MatchString(str) {
-		tok := openAICheck.FindStringSubmatch(str)
-		if len(tok) != 2 {
-			return fmt.Errorf("failed to find openai token in index.ts")
-		}
-		model := tok[1]
-		if err := validateModelSecretSet(logger, data, model); err != nil {
-			return fmt.Errorf("failed to validate model secret: %w", err)
-		}
+	if err := detectModelTokens(logger, data, data.Dir); err != nil {
+		return fmt.Errorf("failed to detect model tokens: %w", err)
 	}
-
 	if err := BundleJS(logger, data.Dir, "node", true); err != nil {
 		return fmt.Errorf("failed to bundle JS: %w", err)
 	}


### PR DESCRIPTION
Moving javascript source code into the `src/` folder broke the automatic model check for API keys. This makes it more robust and fixes that issue.