### PR TITLE
Add support for additional AI providers in our AI Gateway

### DIFF
--- a/internal/bundler/vercel_ai.go
+++ b/internal/bundler/vercel_ai.go
@@ -19,6 +19,19 @@ if (!opts.baseURL) {
 }`, name)
 }
 
+func createVercelAIProviderPatch(module string, createFn string, envkey string, provider string) patchModule {
+	return patchModule{
+		Module: module,
+		Functions: map[string]patchAction{
+			createFn: {
+				Before: generateEnvGuard(envkey,
+					generateVercelAIProvider(provider),
+				),
+			},
+		},
+	}
+}
+
 func init() {
 	var vercelTelemetryPatch = generateJSArgsPatch(0, `experimental_telemetry: { isEnabled: true }`)
 	vercelAIPatches := patchModule{
@@ -44,16 +57,16 @@ func init() {
 			},
 		},
 	}
-	vercelOpenAIPatches := patchModule{
-		Module: "@ai-sdk/openai",
-		Functions: map[string]patchAction{
-			"createOpenAI": {
-				Before: generateEnvGuard("OPENAI_API_KEY",
-					generateVercelAIProvider("openai"),
-				),
-			},
-		},
-	}
 	patches["@vercel/ai"] = vercelAIPatches
-	patches["@vercel/openai"] = vercelOpenAIPatches
+
+	// register all the providers that we support in our Agentuity AI Gateway
+	patches["@vercel/openai"] = createVercelAIProviderPatch("@ai-sdk/openai", "createOpenAI", "OPENAI_API_KEY", "openai")
+	patches["@vercel/anthropic"] = createVercelAIProviderPatch("@ai-sdk/anthropic", "createAnthropic", "ANTHROPIC_API_KEY", "anthropic")
+	patches["@vercel/cohere"] = createVercelAIProviderPatch("@ai-sdk/cohere", "createCohere", "COHERE_API_KEY", "cohere")
+	patches["@vercel/deepseek"] = createVercelAIProviderPatch("@ai-sdk/deepseek", "createDeepSeek", "DEEPSEEK_API_KEY", "deepseek")
+	patches["@vercel/google"] = createVercelAIProviderPatch("@ai-sdk/google", "createGoogleGenerativeAI", "GOOGLE_GENERATIVE_AI_API_KEY", "google")
+	patches["@vercel/xai"] = createVercelAIProviderPatch("@ai-sdk/xai", "createXai", "XAI_API_KEY", "xai")
+	patches["@vercel/groq"] = createVercelAIProviderPatch("@ai-sdk/groq", "createGroq", "GROQ_API_KEY", "groq")
+	patches["@vercel/mistral"] = createVercelAIProviderPatch("@ai-sdk/mistral", "createMistral", "MISTRAL_API_KEY", "mistral")
+	patches["@vercel/perplexity"] = createVercelAIProviderPatch("@ai-sdk/perplexity", "createPerplexity", "PERPLEXITY_API_KEY", "perplexity")
 }


### PR DESCRIPTION
Enable the following additional gateways (beyond openai):

- anthropic
- cohere
- deepseek
- google-ai-studio
- grok
- groq
- mistral
- perplexity-ai