### PR TITLE
Refactor how we handle Agent API keys

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -10,9 +10,11 @@ import (
 )
 
 var bundleCmd = &cobra.Command{
-	Use:    "bundle",
-	Short:  "Run the build bundle process",
-	Hidden: true,
+	Use:     "bundle",
+	Short:   "Run the build bundle process",
+	Args:    cobra.NoArgs,
+	Aliases: []string{"build"},
+	Hidden:  true,
 	Run: func(cmd *cobra.Command, args []string) {
 		started := time.Now()
 		projectContext := ensureProject(cmd)

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -321,7 +321,7 @@ var devRunCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		log := env.NewLogger(cmd)
 		sdkEventsFile := "events.log"
-		dir := resolveProjectDir(cmd)
+		dir := resolveProjectDir(log, cmd)
 		apiUrl, appUrl := getURLs(log)
 		websocketUrl := viper.GetString("overrides.websocket_url")
 		websocketId, _ := cmd.Flags().GetString("websocket-id")

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -230,10 +230,10 @@ func showProjectSelector(items []list.Item) *templates.Template {
 }
 
 var projectNewCmd = &cobra.Command{
-	Use:     "create [name] [description] [agent-name] [agent-description]",
+	Use:     "create [name] [description] [agent-name] [agent-description] [auth-type]",
 	Short:   "Create a new project",
 	Aliases: []string{"new"},
-	Args:    cobra.MaximumNArgs(4),
+	Args:    cobra.MaximumNArgs(5),
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := env.NewLogger(cmd)
 		apikey, _ := ensureLoggedIn()
@@ -247,7 +247,7 @@ var projectNewCmd = &cobra.Command{
 
 		orgId := promptForOrganization(logger, apiUrl, apikey)
 
-		var name, description, agentName, agentDescription string
+		var name, description, agentName, agentDescription, authType string
 
 		if len(args) > 0 {
 			name = args[0]
@@ -356,7 +356,7 @@ var projectNewCmd = &cobra.Command{
 		}
 
 		if agentName == "" {
-			agentName, agentDescription = getAgentInfoFlow(logger, nil, agentName, agentDescription)
+			agentName, agentDescription, authType = getAgentInfoFlow(logger, nil, agentName, agentDescription)
 		}
 
 		var projectData *project.ProjectData
@@ -376,16 +376,18 @@ var projectNewCmd = &cobra.Command{
 			}
 
 			projectData = initProject(logger, InitProjectArgs{
-				BaseURL:          apiUrl,
-				Dir:              projectDir,
-				Token:            apikey,
-				OrgId:            orgId,
-				Name:             name,
-				Description:      description,
-				Provider:         rules,
-				AgentName:        agentName,
-				AgentDescription: agentDescription,
+				BaseURL:           apiUrl,
+				Dir:               projectDir,
+				Token:             apikey,
+				OrgId:             orgId,
+				Name:              name,
+				Description:       description,
+				Provider:          rules,
+				AgentName:         agentName,
+				AgentDescription:  agentDescription,
+				EnableWebhookAuth: authType != "none",
 			})
+
 		})
 
 		tui.ShowBanner("You're ready to deploy your first Agent!",
@@ -393,6 +395,7 @@ var projectNewCmd = &cobra.Command{
 				tui.Secondary("1. Switch into the project directory at ")+tui.Directory(projectDir),
 				tui.Secondary("2. Run ")+tui.Command("run")+tui.Secondary(" to run the project locally in development mode"),
 				tui.Secondary("3. Run ")+tui.Command("deploy")+tui.Secondary(" to deploy the project to the Agentuity Agent Cloud"),
+				tui.Secondary("4. Run ")+tui.Command("agent apikey")+tui.Secondary(" to fetch the API key for the agent"),
 				tui.Secondary("🏠 Access your project at ")+tui.Link("%s/projects/%s", appUrl, projectData.ProjectId),
 			),
 			true,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -129,7 +129,7 @@ func createPromptHelper() deployer.PromptHelpers {
 	}
 }
 
-func resolveProjectDir(cmd *cobra.Command) string {
+func resolveProjectDir(logger logger.Logger, cmd *cobra.Command) string {
 	cwd, err := os.Getwd()
 	if err != nil {
 		errsystem.New(errsystem.ErrEnvironmentVariablesNotSet, err,
@@ -146,8 +146,7 @@ func resolveProjectDir(cmd *cobra.Command) string {
 			errsystem.WithUserMessage(fmt.Sprintf("Failed to get absolute path: %s", err))).ShowErrorAndExit()
 	}
 	if !project.ProjectExists(abs) {
-		errsystem.New(errsystem.ErrInvalidConfiguration, fmt.Errorf("no agentuity.yaml file found"),
-			errsystem.WithUserMessage("No agentuity.yaml file found in the current directory")).ShowErrorAndExit()
+		logger.Fatal("Project file not found: %s", filepath.Join(abs, "agentuity.yaml"))
 	}
 	return abs
 }

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -35,7 +35,7 @@ type BundleContext struct {
 func bundleJavascript(ctx BundleContext, dir string, outdir string, theproject *project.Project) error {
 	var entryPoints []string
 	entryPoints = append(entryPoints, filepath.Join(dir, "index.js"))
-	files, err := util.ListDir(theproject.Bundler.AgentConfig.Dir)
+	files, err := util.ListDir(filepath.Join(dir, theproject.Bundler.AgentConfig.Dir))
 	if err != nil {
 		errsystem.New(errsystem.ErrListFilesAndDirectories, err).ShowErrorAndExit()
 	}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -21,6 +21,8 @@ const (
 	initPath = "/cli/project"
 )
 
+var Version string
+
 type initProjectResult struct {
 	Success bool        `json:"success"`
 	Data    ProjectData `json:"data"`
@@ -138,6 +140,7 @@ type AgentConfig struct {
 }
 
 type Project struct {
+	Version     string        `json:"version" yaml:"version" hc:"The version semver range required to run this project"`
 	ProjectId   string        `json:"project_id" yaml:"project_id" hc:"The ID of the project which is automatically generated"`
 	Name        string        `json:"name" yaml:"name" hc:"The name of the project which is editable"`
 	Description string        `json:"description" yaml:"description" hc:"The description of the project which is editable"`
@@ -229,7 +232,14 @@ const (
 
 // NewProject will create a new project that is empty.
 func NewProject() *Project {
+	var version string
+	if Version == "" || Version == "dev" {
+		version = ">=0.0.0" // should only happen in dev cli
+	} else {
+		version = Version
+	}
 	return &Project{
+		Version: version,
 		Deployment: &Deployment{
 			Resources: &Resources{
 				Memory: defaultMemory,

--- a/internal/tui/banner.go
+++ b/internal/tui/banner.go
@@ -12,7 +12,7 @@ var (
 	bannerTitleColor     = lipgloss.AdaptiveColor{Light: "#36EEE0", Dark: "#00FFFF"}
 	bannerMaxWidth       = 80
 	bannerPadding        = 1
-	bannerMargin         = 1
+	bannerMargin         = 0
 	bannerBorder         = lipgloss.RoundedBorder()
 	bannerStyle          = lipgloss.NewStyle().
 				Padding(bannerPadding).

--- a/internal/tui/logo.go
+++ b/internal/tui/logo.go
@@ -38,6 +38,9 @@ var (
 )
 
 func Logo() {
+	if !HasTTY {
+		return
+	}
 	logo := logoStyle.Render(logoHeader)
 	title := logoStyle.Render("Agentuity Agent Cloud")
 	fmt.Println(logoBox.Render(logo + "\n" + title))

--- a/internal/tui/message.go
+++ b/internal/tui/message.go
@@ -15,6 +15,8 @@ var (
 	messageTextStyle    = lipgloss.NewStyle().Foreground(messageTextColor)
 	messageWarningColor = lipgloss.AdaptiveColor{Light: "#990000", Dark: "#FF0000"}
 	messageWarningStyle = lipgloss.NewStyle().Foreground(messageWarningColor)
+	messageLockColor    = lipgloss.AdaptiveColor{Light: "#DE970B", Dark: "#F6BE00"}
+	messageLockStyle    = lipgloss.NewStyle().Foreground(messageLockColor)
 )
 
 func ShowSuccess(msg string, args ...any) {
@@ -24,7 +26,8 @@ func ShowSuccess(msg string, args ...any) {
 }
 
 func ShowLock(msg string, args ...any) {
-	fmt.Printf(" 🔒 %s", messageTextStyle.Render(fmt.Sprintf(msg, args...)))
+	body := messageLockStyle.Render(" 🔒" + messageLockStyle.Render(fmt.Sprintf(msg, args...)))
+	fmt.Println(body)
 	fmt.Println()
 }
 

--- a/internal/tui/spinner.go
+++ b/internal/tui/spinner.go
@@ -14,6 +14,10 @@ var (
 
 // ShowSpinner will display a spinner while the action is being performed
 func ShowSpinner(title string, action func()) {
+	if !HasTTY {
+		action()
+		return
+	}
 	var wg sync.WaitGroup
 	if currentSpinnerDone != nil {
 		currentSpinnerDone()

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1,0 +1,11 @@
+package tui
+
+import (
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+var (
+	HasTTY = isatty.IsTerminal(os.Stdout.Fd())
+)

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ package main
 import (
 	"github.com/agentuity/cli/cmd"
 	"github.com/agentuity/cli/internal/errsystem"
+	"github.com/agentuity/cli/internal/project"
 )
 
 var (
@@ -37,5 +38,6 @@ func main() {
 	cmd.Commit = commit
 	cmd.Date = date
 	errsystem.Version = version
+	project.Version = version
 	cmd.Execute()
 }


### PR DESCRIPTION
- Refactor how we handle Agent API Keys and fix a few small isses
- Just make either [dev] or [run] from the root
- Add support for CLI versioning in project file
