### PR TITLE
Add support for new transport domain

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -36,7 +36,7 @@ var agentDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := env.NewLogger(cmd)
 		theproject := project.EnsureProject(cmd)
-		apiUrl, _ := getURLs(logger)
+		apiUrl, _, _ := util.GetURLs(logger)
 
 		keys, state := reconcileAgentList(logger, apiUrl, theproject.Token, theproject)
 
@@ -133,7 +133,7 @@ var agentCreateCmd = &cobra.Command{
 		logger := env.NewLogger(cmd)
 		theproject := project.EnsureProject(cmd)
 		apikey := theproject.Token
-		apiUrl, _ := getURLs(logger)
+		apiUrl, _, _ := util.GetURLs(logger)
 
 		var remoteAgents []agent.Agent
 
@@ -394,7 +394,7 @@ var agentListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := env.NewLogger(cmd)
 		project := project.EnsureProject(cmd)
-		apiUrl, _ := getURLs(logger)
+		apiUrl, _, _ := util.GetURLs(logger)
 
 		// perform the reconcilation
 		keys, state := reconcileAgentList(logger, apiUrl, project.Token, project)
@@ -427,7 +427,7 @@ var agentGetApiKeyCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := env.NewLogger(cmd)
 		project := project.EnsureProject(cmd)
-		apiUrl, _ := getURLs(logger)
+		apiUrl, _, _ := util.GetURLs(logger)
 
 		// perform the reconcilation
 		keys, state := reconcileAgentList(logger, apiUrl, project.Token, project)

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -27,7 +27,7 @@ var authLoginCmd = &cobra.Command{
 	Short: "Login to the Agentuity Platform",
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := env.NewLogger(cmd)
-		apiUrl, appUrl := getURLs(logger)
+		apiUrl, appUrl, _ := util.GetURLs(logger)
 		var otp string
 		loginaction := func() {
 			var err error
@@ -95,7 +95,7 @@ var authWhoamiCmd = &cobra.Command{
 	Short: "Print the current logged in user details",
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := env.NewLogger(cmd)
-		apiUrl, _ := getURLs(logger)
+		apiUrl, _, _ := util.GetURLs(logger)
 		apiKey, userId := util.EnsureLoggedIn()
 		user, err := auth.GetUser(logger, apiUrl, apiKey)
 		if err != nil {

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -115,6 +115,7 @@ var cloudDeployCmd = &cobra.Command{
 		dir := context.Dir
 		apiUrl := context.APIURL
 		appUrl := context.APPURL
+		transportUrl := context.TransportURL
 		token := context.Token
 
 		var keys []string
@@ -487,7 +488,7 @@ var cloudDeployCmd = &cobra.Command{
 					body2 += tui.Body("· Run ") + tui.Command("agent apikey "+theproject.Agents[0].ID) + tui.Body("\n  to fetch the API key for this webhook")
 					body2 += "\n\n"
 				}
-				body2 += tui.Body(fmt.Sprintf("· Send %s webhook request to\n  ", theproject.Agents[0].Name) + tui.Link("%s/run/%s", apiUrl, theproject.Agents[0].ID))
+				body2 += tui.Body(fmt.Sprintf("· Send %s webhook request to\n  ", theproject.Agents[0].Name) + tui.Link("%s/%s", transportUrl, strings.TrimLeft(theproject.Agents[0].ID, "agent_")))
 			}
 
 			tui.ShowBanner("Your project was deployed successfully!", body+body2, true)

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -28,7 +28,7 @@ var devRunCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		log := env.NewLogger(cmd)
 		dir := project.ResolveProjectDir(log, cmd)
-		_, appUrl := getURLs(log)
+		_, appUrl, _ := util.GetURLs(log)
 		websocketUrl := viper.GetString("overrides.websocket_url")
 		websocketId, _ := cmd.Flags().GetString("websocket-id")
 		apiKey, _ := util.EnsureLoggedIn()

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/agentuity/cli/internal/tui"
+	"github.com/agentuity/cli/internal/util"
+	"github.com/agentuity/go-common/env"
+	"github.com/agentuity/go-common/logger"
+	"github.com/agentuity/go-common/sys"
+	"github.com/spf13/cobra"
+)
+
+type profile struct {
+	name     string
+	filename string
+	selected bool
+}
+
+var profileNameRegex = regexp.MustCompile(`name:\s+["]?([\w-_]+)["]?`)
+var profileNameValidRegex = regexp.MustCompile(`^[\w-_]{3,}$`)
+
+func saveProfile(name string) {
+	fn := filepath.Join(filepath.Dir(cfgFile), "profile")
+	os.WriteFile(fn, []byte(name), 0644)
+}
+
+func getProfile() string {
+	dir := filepath.Dir(cfgFile)
+	fn := filepath.Join(dir, "profile")
+	if util.Exists(fn) {
+		buf, _ := os.ReadFile(fn)
+		filename := strings.TrimSpace(string(buf))
+		if util.Exists(filename) {
+			return filename
+		}
+	}
+	return cfgFile
+}
+
+func fetchProfiles() []profile {
+	dir := filepath.Dir(cfgFile)
+	var profiles []profile
+	files, _ := sys.ListDir(dir)
+	for _, file := range files {
+		if filepath.Ext(file) == ".yaml" {
+			buf, _ := os.ReadFile(file)
+			m := profileNameRegex.FindStringSubmatch(string(buf))
+			if len(m) > 0 {
+				profiles = append(profiles, profile{m[1], file, file == cfgFile})
+			}
+		}
+	}
+	return profiles
+}
+
+func selectProfile(logger logger.Logger) string {
+	profiles := fetchProfiles()
+	var opts []tui.Option
+	for _, p := range profiles {
+		prepend := " "
+		if p.selected {
+			prepend = "•"
+		}
+		opts = append(opts, tui.Option{Selected: p.selected, ID: p.filename, Text: prepend + " " + tui.PadRight(p.name, 15, " ") + " " + tui.Muted(filepath.Base(filepath.Dir(p.filename))+"/"+filepath.Base(p.filename))})
+	}
+	return tui.Select(logger, "Select a profile\n", "", opts)
+}
+
+var profileCmd = &cobra.Command{
+	Use:    "profile",
+	Args:   cobra.NoArgs,
+	Short:  "Manage profiles",
+	Hidden: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+var profileUseCmd = &cobra.Command{
+	Use:    "use [name]",
+	Args:   cobra.MaximumNArgs(1),
+	Short:  "Use a different profile",
+	Hidden: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		logger := env.NewLogger(cmd)
+		var name string
+		if len(args) > 0 {
+			name = args[0]
+			profiles := fetchProfiles()
+			var found bool
+			for _, profile := range profiles {
+				if profile.name == name {
+					name = profile.filename
+					found = true
+					break
+				}
+			}
+			if !found {
+				name = ""
+			}
+		}
+		if name == "" {
+			name = selectProfile(logger)
+		}
+		saveProfile(name)
+	},
+}
+
+var profileCreateCmd = &cobra.Command{
+	Use:    "create",
+	Args:   cobra.NoArgs,
+	Short:  "Create a new empty profile",
+	Hidden: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		logger := env.NewLogger(cmd)
+		profiles := fetchProfiles()
+		name := tui.InputWithValidation(logger, "Name your profile", "Choose a short unique name", 0, func(val string) error {
+			if val == "" {
+				return fmt.Errorf("profile name cannot be empty")
+			}
+			if !profileNameValidRegex.MatchString(val) {
+				return fmt.Errorf("profile name must match: %s", profileNameValidRegex.String())
+			}
+			for _, profile := range profiles {
+				if profile.name == val {
+					return fmt.Errorf("profile name %s already exists", val)
+				}
+			}
+			return nil
+		})
+		fp := filepath.Join(filepath.Dir(cfgFile), util.SafeFilename(name)+".yaml")
+		os.WriteFile(fp, []byte(fmt.Sprintf(`name: "%s"`, name)+"\n"), 0644)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(profileCmd)
+	profileCmd.AddCommand(profileUseCmd)
+	profileCmd.AddCommand(profileCreateCmd)
+}

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -291,7 +291,8 @@ var projectNewCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := env.NewLogger(cmd)
 		apikey, _ := util.EnsureLoggedIn()
-		apiUrl, appUrl := getURLs(logger)
+		apiUrl, appUrl, _ := util.GetURLs(logger)
+
 		initScreenWithLogo()
 
 		cwd, err := os.Getwd()
@@ -523,7 +524,8 @@ var projectListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := env.NewLogger(cmd)
 		apikey, _ := util.EnsureLoggedIn()
-		apiUrl, _ := getURLs(logger)
+		apiUrl, _, _ := util.GetURLs(logger)
+
 		var projects []project.ProjectListData
 		action := func() {
 			var err error
@@ -562,7 +564,7 @@ var projectDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := env.NewLogger(cmd)
 		apikey, _ := util.EnsureLoggedIn()
-		apiUrl, _ := getURLs(logger)
+		apiUrl, _, _ := util.GetURLs(logger)
 		var projects []project.ProjectListData
 		action := func() {
 			var err error

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -97,6 +97,7 @@ func initConfig() {
 			}
 		}
 		cfgFile = filepath.Join(dir, "config.yaml")
+		cfgFile = getProfile()
 		viper.SetConfigFile(cfgFile)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/agentuity/cli/internal/deployer"
 	"github.com/agentuity/cli/internal/tui"
-	"github.com/agentuity/go-common/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -66,12 +65,17 @@ func init() {
 	rootCmd.PersistentFlags().MarkHidden("websocket-url")
 	viper.BindPFlag("overrides.websocket_url", rootCmd.PersistentFlags().Lookup("websocket-url"))
 
+	rootCmd.PersistentFlags().String("transport-url", "https://agentuity.ai", "The base url of the Agentuity Transport API")
+	rootCmd.PersistentFlags().MarkHidden("transport-url")
+	viper.BindPFlag("overrides.transport_url", rootCmd.PersistentFlags().Lookup("transport-url"))
+
 	rootCmd.PersistentFlags().String("api-key", "", "The API key to use for authentication")
 	rootCmd.PersistentFlags().MarkHidden("api-key")
 	viper.BindPFlag("auth.api_key", rootCmd.PersistentFlags().Lookup("api-key"))
 
 	viper.SetDefault("overrides.app_url", "https://app.agentuity.com")
 	viper.SetDefault("overrides.api_url", "https://api.agentuity.com")
+	viper.SetDefault("overrides.transport_url", "https://agentuity.ai")
 
 	cobra.OnInitialize(initConfig)
 }
@@ -129,17 +133,4 @@ func createPromptHelper() deployer.PromptHelpers {
 		Ask:           tui.Ask,
 		PromptForEnv:  promptForEnv,
 	}
-}
-
-func getURLs(logger logger.Logger) (string, string) {
-	appUrl := viper.GetString("overrides.app_url")
-	apiUrl := viper.GetString("overrides.api_url")
-	if apiUrl == "https://api.agentuity.com" && appUrl != "https://app.agentuity.com" {
-		logger.Debug("switching app url to production since the api url is production")
-		appUrl = "https://app.agentuity.com"
-	} else if apiUrl == "https://api.agentuity.div" && appUrl == "https://app.agentuity.com" {
-		logger.Debug("switching app url to dev since the api url is dev")
-		appUrl = "http://localhost:3000"
-	}
-	return apiUrl, appUrl
 }

--- a/internal/tui/select.go
+++ b/internal/tui/select.go
@@ -13,9 +13,14 @@ func Select(logger logger.Logger, title string, description string, items []Opti
 		opts = append(opts, huh.NewOption(item.Text, item.ID).Selected(item.Selected))
 	}
 
+	descriptionText := description
+	if description != "" && description != "\n" {
+		descriptionText += "\n"
+	}
+
 	if err := huh.NewSelect[string]().
 		Title(title).
-		Description(description + "\n").
+		Description(descriptionText).
 		Options(opts...).
 		Value(&selected).Run(); err != nil {
 		logger.Fatal("%s", err)

--- a/internal/util/api.go
+++ b/internal/util/api.go
@@ -170,17 +170,25 @@ func TransformUrl(urlString string) string {
 	return urlString
 }
 
-func GetURLs(logger logger.Logger) (string, string) {
+func GetURLs(logger logger.Logger) (string, string, string) {
 	appUrl := viper.GetString("overrides.app_url")
 	apiUrl := viper.GetString("overrides.api_url")
+	transportUrl := viper.GetString("overrides.transport_url")
 	if apiUrl == "https://api.agentuity.com" && appUrl != "https://app.agentuity.com" {
 		logger.Debug("switching app url to production since the api url is production")
 		appUrl = "https://app.agentuity.com"
-	} else if apiUrl == "https://api.agentuity.div" && appUrl == "https://app.agentuity.com" {
+	} else if apiUrl == "https://api.agentuity.dev" && appUrl == "https://app.agentuity.com" {
 		logger.Debug("switching app url to dev since the api url is dev")
 		appUrl = "http://localhost:3000"
 	}
-	return TransformUrl(apiUrl), TransformUrl(appUrl)
+	if apiUrl == "https://api.agentuity.com" && transportUrl != "https://agentuity.api" {
+		logger.Debug("switching transport url to production since the api url is production")
+		transportUrl = "https://agentuity.ai"
+	} else if apiUrl == "https://api.agentuity.dev" && appUrl == "https://agentuity.ai" {
+		logger.Debug("switching transport url to dev since the api url is dev")
+		transportUrl = "http://localhost:3939"
+	}
+	return TransformUrl(apiUrl), TransformUrl(appUrl), TransformUrl(transportUrl)
 }
 
 func ShowLogin() {

--- a/internal/util/api.go
+++ b/internal/util/api.go
@@ -184,7 +184,7 @@ func GetURLs(logger logger.Logger) (string, string, string) {
 	if apiUrl == "https://api.agentuity.com" && transportUrl != "https://agentuity.api" {
 		logger.Debug("switching transport url to production since the api url is production")
 		transportUrl = "https://agentuity.ai"
-	} else if apiUrl == "https://api.agentuity.dev" && appUrl == "https://agentuity.ai" {
+	} else if apiUrl == "https://api.agentuity.dev" && transportUrl == "https://agentuity.ai" {
 		logger.Debug("switching transport url to dev since the api url is dev")
 		transportUrl = "http://localhost:3939"
 	}


### PR DESCRIPTION
This PR adds support for the new agentuity.ai domain which we will use for agent transport and communication protocols.

Also, snuck in support for profile switching for local development when switching between servers.