### PR TITLE
Handle auth failure better

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -138,6 +138,10 @@ Examples:
 			errsystem.New(errsystem.ErrAuthenticateUser, err,
 				errsystem.WithContextMessage("Failed to get user")).ShowErrorAndExit()
 		}
+		if user == nil {
+			util.ShowLogin()
+			os.Exit(1)
+		}
 		var orgs []string
 		orgs = append(orgs, tui.Bold(tui.Muted("You are a member of the following organizations:")))
 		for _, org := range user.Organizations {

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -139,6 +139,10 @@ Examples:
 				errsystem.WithContextMessage("Failed to get user")).ShowErrorAndExit()
 		}
 		if user == nil {
+			viper.Set("auth.api_key", "")
+			viper.Set("auth.user_id", "")
+			viper.Set("auth.expires", time.Now().UnixMilli())
+			viper.WriteConfig()
 			util.ShowLogin()
 			os.Exit(1)
 		}

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/agentuity/cli/internal/util"
@@ -100,6 +101,12 @@ func GetUser(ctx context.Context, logger logger.Logger, baseUrl string, apiKey s
 
 	var resp UserResponse
 	if err := client.Do("GET", "/cli/auth/user", nil, &resp); err != nil {
+		var apiErr *util.APIError
+		if errors.As(err, &apiErr) {
+			if apiErr.Status == http.StatusUnauthorized {
+				return nil, nil
+			}
+		}
 		return nil, err
 	}
 	if !resp.Success {


### PR DESCRIPTION
If the session is expired on whoami route, should show the correct login banner instead of showing error banner.