### PR TITLE
Initial Implementation of Automatic Version checking

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -199,6 +199,8 @@ var agentCreateCmd = &cobra.Command{
 			initScreenWithLogo()
 		}
 
+		checkForUpgrade(ctx)
+
 		var err error
 		remoteAgents, err = getAgentList(logger, apiUrl, apikey, theproject)
 		if err != nil {

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -45,6 +45,7 @@ Examples:
 		var otp string
 		ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 		defer cancel()
+		checkForUpgrade(ctx)
 		loginaction := func() {
 			var err error
 			otp, err = auth.GenerateLoginOTP(ctx, logger, apiUrl)

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -45,7 +45,6 @@ Examples:
 		var otp string
 		ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 		defer cancel()
-		checkForUpgrade(ctx)
 		loginaction := func() {
 			var err error
 			otp, err = auth.GenerateLoginOTP(ctx, logger, apiUrl)
@@ -95,6 +94,7 @@ Examples:
 		tui.ClearScreen()
 		initScreenWithLogo()
 		tui.ShowSuccess("Welcome to Agentuity! You are now logged in")
+		checkForUpgrade(ctx)
 	},
 }
 

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -145,6 +145,8 @@ Examples:
 		ctx, cancel := signal.NotifyContext(parentCtx, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 		defer cancel()
 
+		checkForUpgrade(ctx)
+
 		var keys []string
 		var state map[string]agentListState
 

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -324,6 +324,8 @@ Examples:
 			errsystem.New(errsystem.ErrListFilesAndDirectories, err, errsystem.WithContextMessage("Failed to get current working directory")).ShowErrorAndExit()
 		}
 
+		checkForUpgrade(ctx)
+
 		orgId := promptForOrganization(ctx, logger, apiUrl, apikey)
 
 		var name, description, agentName, agentDescription, authType string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,8 +7,10 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/agentuity/cli/internal/deployer"
+	"github.com/agentuity/cli/internal/util"
 	"github.com/agentuity/go-common/tui"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -149,5 +151,23 @@ func isCancelled(ctx context.Context) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func checkForUpgrade(ctx context.Context) {
+	v := viper.GetInt64("preferences.last_update_check")
+	var check bool
+	if v == 0 {
+		check = true
+	} else {
+		n := time.Unix(v, 0)
+		if time.Since(n) >= 24*time.Hour {
+			check = true
+		}
+	}
+	if check {
+		viper.Set("preferences.last_update_check", time.Now().Unix())
+		viper.WriteConfig()
+		util.CheckLatestRelease(ctx)
 	}
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,8 +1,16 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 
+	"github.com/Masterminds/semver"
+	"github.com/agentuity/cli/internal/util"
+	"github.com/agentuity/go-common/env"
+	"github.com/agentuity/go-common/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +37,44 @@ Examples:
 	},
 }
 
+var versionCheckCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Check the latest version of the Agentuity CLI",
+	Long: `Check the latest version of the Agentuity CLI.
+
+Examples:
+  agentuity version check
+  agentuity version check --upgrade`,
+	Run: func(cmd *cobra.Command, args []string) {
+		upgrade, _ := cmd.Flags().GetBool("upgrade")
+		if Version == "dev" {
+			tui.ShowWarning("You are using the development version of the Agentuity CLI.")
+			return
+		}
+		ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+		defer cancel()
+		if upgrade {
+			util.CheckLatestRelease(ctx)
+		} else {
+			release, err := util.GetLatestRelease(ctx)
+			if err != nil {
+				logger := env.NewLogger(cmd)
+				logger.Fatal("%s", err)
+			}
+			latestVersion := semver.MustParse(release)
+			currentVersion := semver.MustParse(Version)
+			if latestVersion.GreaterThan(currentVersion) {
+				tui.ShowWarning("A new version (%s) of the Agentuity CLI is available. Please upgrade to the latest version.", release)
+			} else {
+				tui.ShowSuccess("You are using the latest version (%s) of the Agentuity CLI.", release)
+			}
+		}
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(versionCmd)
+	versionCmd.AddCommand(versionCheckCmd)
 	versionCmd.Flags().Bool("long", false, "Print the long version")
+	versionCheckCmd.Flags().Bool("upgrade", false, "Upgrade to the latest version if possible")
 }

--- a/internal/util/api.go
+++ b/internal/util/api.go
@@ -82,6 +82,18 @@ type APIResponse struct {
 	} `json:"error"`
 }
 
+func UserAgent() string {
+	gitSHA := Commit
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				gitSHA = setting.Value
+			}
+		}
+	}
+	return "Agentuity CLI/" + Version + " (" + gitSHA + ")"
+}
+
 func (c *APIClient) Do(method, path string, payload interface{}, response interface{}) error {
 	var traceID string
 
@@ -104,15 +116,7 @@ func (c *APIClient) Do(method, path string, payload interface{}, response interf
 	if err != nil {
 		return NewAPIError(u.String(), method, 0, "", fmt.Errorf("error creating request: %w", err), traceID)
 	}
-	gitSHA := Commit
-	if info, ok := debug.ReadBuildInfo(); ok {
-		for _, setting := range info.Settings {
-			if setting.Key == "vcs.revision" {
-				gitSHA = setting.Value
-			}
-		}
-	}
-	req.Header.Set("User-Agent", "Agentuity CLI/"+Version+" ("+gitSHA+")")
+	req.Header.Set("User-Agent", UserAgent())
 	req.Header.Set("Content-Type", "application/json")
 	if c.token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.token)

--- a/internal/util/version.go
+++ b/internal/util/version.go
@@ -1,0 +1,119 @@
+package util
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/Masterminds/semver"
+	"github.com/agentuity/go-common/tui"
+	"golang.org/x/term"
+)
+
+// GetLatestRelease returns the latest release tag name from the GitHub API
+func GetLatestRelease(ctx context.Context) (string, error) {
+	if Version == "dev" {
+		return Version, nil
+	}
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://api.github.com/repos/agentuity/cli/releases/latest", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", UserAgent())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to check for latest release: %s", resp.Status)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", err
+	}
+	return release.TagName, nil
+}
+
+func CheckLatestRelease(ctx context.Context) error {
+	if Version == "dev" {
+		return nil
+	}
+
+	release, err := GetLatestRelease(ctx)
+	if err != nil {
+		return err
+	}
+	latestVersion := semver.MustParse(release)
+	currentVersion := semver.MustParse(Version)
+	if latestVersion.GreaterThan(currentVersion) {
+		showUpgradeNotice(release)
+	}
+	return nil
+}
+
+func showUpgradeNotice(version string) {
+	if runtime.GOOS == "darwin" {
+		exe, err := os.Executable()
+		if err != nil {
+			return
+		}
+		// if we are running from homebrew, we need to upgrade via homebrew
+		if tui.HasTTY && strings.Contains(exe, "/homebrew/Cellar/agentuity/") {
+			answer := ask(tui.Bold(fmt.Sprintf("Agentuity version %s is available. Would you like to upgrade? [Y/n] ", version)), "Y")
+			fmt.Println()
+			if answer == "Y" || answer == "y" {
+				action := func() {
+					exec.Command("brew", "update").Run()
+					exec.Command("brew", "upgrade", "agentuity").Run()
+					v, _ := exec.Command(exe, "version").Output()
+					if strings.TrimSpace(string(v)) == version {
+						tui.ShowSuccess("Upgraded to %s", version)
+						return
+					}
+					tui.ShowWarning("Failed to upgrade. Please run `brew update && brew upgrade agentuity` manually.")
+				}
+				tui.ShowSpinner("Upgrading...", action)
+			}
+			return
+		}
+	}
+	tui.ShowBanner("Agentuity Upgrade", fmt.Sprintf("Agentuity version %s is available. See %s for more information.", version, tui.Link("https://agentuity.dev/CLI/installation")), false)
+}
+
+func ask(message string, defaultValue string) string {
+	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		return ""
+	}
+	defer term.Restore(int(os.Stdin.Fd()), oldState)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+	ch := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 1)
+		os.Stdin.Read(buf)
+		ch <- string(buf)
+	}()
+	fmt.Print(message)
+	select {
+	case <-ctx.Done():
+		return ""
+	case answer := <-ch:
+		if answer == "\n" || answer == "\r" {
+			return defaultValue
+		}
+		return answer
+	}
+}


### PR DESCRIPTION
This is the initial version of the version check.  Mid-term we're going to support automatic self-upgrade but for now, we can at least check every 24 hours for a new release and attempt to upgrade.

For the self-upgrade, it only works if agentuity is installed with Homebrew (on Mac), otherwise, will just show an upgrade banner with a link to instructions.

For non-brew:

<img width="679" alt="image" src="https://github.com/user-attachments/assets/9072a890-867d-4d15-a0ef-a18e2755d88e" />

For brew:

<img width="580" alt="image" src="https://github.com/user-attachments/assets/e8e7cc7a-9032-4c1b-996e-80b115772b04" />

