### PR TITLE
Python: force --env-file when running in devmode

### DIFF
--- a/internal/templates/data/python-uv/rules.yaml
+++ b/internal/templates/data/python-uv/rules.yaml
@@ -16,6 +16,7 @@ development:
   command: uv
   args:
     - run
+    - --env-file .env
     - server.py
 deployment:
   resources:


### PR DESCRIPTION
Not sure what's going on but the version of uv (uv 0.5.25) seems to not require it and pick it up automatically but a later version (uv 0.6.6) doesn't so this will force in all cases.