### PR TITLE
Windows installer and MCP fixes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,8 @@ builds:
       - darwin
 
 archives:
-  - formats: ['tar.gz']
+  - id: "agentuity"
+    formats: ['tar.gz']
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       agentuity_
@@ -39,15 +40,16 @@ archives:
         formats: ['zip']
 checksum:
   name_template: "checksums.txt"
+
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
+
 changelog:
   sort: asc
   filters:
     exclude:
       - "^docs:"
       - "^test:"
-
 
 notarize:
   macos:
@@ -100,8 +102,11 @@ notarize:
         # Not recommended, as it could take a really long time.
         wait: false
         # timeout: 20m
+
 brews:
   - name: agentuity
+    ids:
+      - agentuity
     repository:
       owner: agentuity
       name: homebrew-tap
@@ -115,3 +120,14 @@ brews:
       bin.install "agentuity"
     alternative_names:
       - "agentuity@{{ .Version }}"
+
+msi:
+  - id: agentuity
+    name: "agentuity-{{.MsiArch}}"
+    wxs: ./installer.wsx
+    ids:
+      - agentuity
+    goamd64: v1
+    replace: true
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    version: v3

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -9,6 +9,7 @@ import (
 	"github.com/agentuity/cli/internal/bundler"
 	"github.com/agentuity/cli/internal/errsystem"
 	"github.com/agentuity/cli/internal/project"
+	"github.com/agentuity/cli/internal/util"
 	"github.com/spf13/cobra"
 )
 
@@ -76,6 +77,7 @@ Examples:
 				projectContext.Logger.Fatal("Failed to get current working directory: %s", err)
 			}
 			c := exec.Command(bin, args...)
+			util.ProcessSetup(c)
 			c.Dir = cwd
 			c.Stdin = nil
 			c.Env = os.Environ()

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -308,6 +308,7 @@ func showItemSelector(title string, items []list.Item) list.Item {
 
 func gitCommand(ctx context.Context, projectDir string, git string, args ...string) error {
 	c := exec.CommandContext(ctx, git, args...)
+	util.ProcessSetup(c)
 	c.Dir = projectDir
 	return c.Run()
 }

--- a/installer.wsx
+++ b/installer.wsx
@@ -1,0 +1,88 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
+  {{ if eq .MsiArch "x64" }}
+  <?define ArchString = "(64 bit)" ?>
+  <?define Win64 = "yes" ?>
+  <?define ProgramFilesFolder = "ProgramFiles64Folder" ?>
+  {{ else }}
+  <?define ArchString = "" ?>
+  <?define Win64 = "no" ?>
+  <?define ProgramFilesFolder = "ProgramFilesFolder" ?>
+  {{ end }}
+  <Product
+    Name='Agentuity {{.Version}}'
+    Id='ABCDDCBA-86C7-4D14-AEC0-86413A69ABDE'
+    UpgradeCode='ABCDDCBA-7349-453F-94F6-BCB5110BA8FD'
+    Language='1033'
+    Codepage='1252'
+    Version='{{.Version}}'
+    Manufacturer='Agentuity, Inc.'>
+
+    <Package
+      Id='*'
+      Keywords='Installer'
+      Description="Agentuity installer"
+      Manufacturer='Agentuity, Inc.'
+      InstallerVersion='200'
+      Languages='1033'
+      Compressed='yes'
+      SummaryCodepage='1252'
+    />
+
+    <Media
+      Id='1'
+      Cabinet='Sample.cab'
+      EmbedCab='yes'
+      DiskPrompt="CD-ROM #1"
+    />
+
+    <Property
+      Id='DiskPrompt'
+      Value="Agentuity {{.Version}} Installation [1]"
+    />
+
+    <Property Id="WIXUI_INSTALLDIR" Value="TARGETDIR" />
+    <Property Id="ALLUSERS" Value="1" />
+
+    <Directory Id='TARGETDIR' Name='SourceDir'>
+      <Directory Id='ProgramFilesFolder' Name='PFiles'>
+        <Directory Id='Agentuity' Name='Agentuity'>
+          <Component
+            Id='PathComponent'
+            Guid='ABCDDCBA-83F1-4F22-985B-FDB3C8ABD476'
+            Win64='$(var.Win64)'
+          >
+            <Environment 
+              Id="PATH"
+              Name="PATH"
+              Value="[Agentuity]"
+              Permanent="no"
+              Part="last"
+              Action="set"
+              System="yes"
+            />
+          </Component>
+          <Component
+            Id='MainExecutable'
+            Guid='ABCDDCBA-83F1-4F22-985B-FDB3C8ABD474'
+            Win64='$(var.Win64)'
+          >
+            <File
+              Id='agentuity.exe'
+              Name='agentuity.exe'
+              DiskId='1'
+              Source='agentuity.exe'
+              KeyPath='yes'
+            />
+          </Component>
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <Feature Id='Complete' Level='1'>
+      <ComponentRef Id='PathComponent' />
+      <ComponentRef Id='MainExecutable' />
+    </Feature>
+
+  </Product>
+</Wix>

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -47,6 +47,7 @@ func bundleJavascript(ctx BundleContext, dir string, outdir string, theproject *
 		default:
 			return fmt.Errorf("unsupported runtime: %s", theproject.Bundler.Runtime)
 		}
+		util.ProcessSetup(install)
 		install.Dir = dir
 		out, err := install.CombinedOutput()
 		if err != nil {
@@ -155,6 +156,7 @@ func bundlePython(ctx BundleContext, dir string, outdir string, theproject *proj
 		default:
 			return fmt.Errorf("unsupported runtime: %s", theproject.Bundler.Runtime)
 		}
+		util.ProcessSetup(install)
 		install.Dir = dir
 		out, err := install.CombinedOutput()
 		if err != nil {

--- a/internal/dev/dev.go
+++ b/internal/dev/dev.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/agentuity/cli/internal/project"
+	"github.com/agentuity/cli/internal/util"
 	"github.com/agentuity/go-common/logger"
 )
 
@@ -25,7 +26,7 @@ func KillProjectServer(projectServerCmd *exec.Cmd) {
 		break
 	case <-time.After(time.Second * 10):
 		// this will kill the process group not just the parent process
-		syscall.Kill(-projectServerCmd.Process.Pid, syscall.SIGKILL)
+		util.ProcessKill(projectServerCmd)
 	}
 }
 
@@ -89,8 +90,7 @@ func CreateRunProjectCmd(log logger.Logger, theproject project.ProjectContext, l
 	projectServerCmd.Stderr = os.Stderr
 	projectServerCmd.Stdin = os.Stdin
 
-	// set this process as the parent of the process group since it will likely span child processes
-	projectServerCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	util.ProcessSetup(projectServerCmd)
 
 	return projectServerCmd, nil
 }

--- a/internal/mcp/util.go
+++ b/internal/mcp/util.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 
 	"github.com/agentuity/cli/internal/project"
+	"github.com/agentuity/cli/internal/util"
 	mcp_golang "github.com/agentuity/mcp-golang/v2"
 )
 
@@ -40,6 +41,7 @@ func execCommand(ctx context.Context, dir string, command string, args ...string
 	args = append([]string{command}, args...)
 	args = append(args, "--log-level", "warn")
 	cmd := exec.CommandContext(ctx, exe, args...)
+	util.ProcessSetup(cmd)
 	if dir != "" {
 		cmd.Dir = dir
 	}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -255,8 +256,11 @@ func ProjectWithNameExists(ctx context.Context, logger logger.Logger, baseUrl st
 	if err := client.Do("GET", fmt.Sprintf("/cli/project/exists/%s", url.PathEscape(name)), nil, &resp); err != nil {
 		var apiErr *util.APIError
 		if errors.As(err, &apiErr) {
-			if apiErr.Status == 409 {
+			if apiErr.Status == http.StatusConflict {
 				return true, nil
+			}
+			if apiErr.Status == http.StatusUnprocessableEntity {
+				return false, apiErr
 			}
 		}
 		return false, fmt.Errorf("error validating project name: %w", err)

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -47,6 +47,7 @@ func (r *Requirement) checkForBrew(brew string, formula string) bool {
 	c.Stdin = nil
 	c.Stdout = io.Discard
 	c.Stderr = io.Discard
+	util.ProcessSetup(c)
 	out, err := c.Output()
 	if err != nil {
 		return false
@@ -62,6 +63,7 @@ func (r *Requirement) upgradeBrew(brew string, formula string) error {
 	c.Stdin = nil
 	c.Stdout = io.Discard
 	c.Stderr = io.Discard
+	util.ProcessSetup(c)
 	if err := c.Run(); err != nil {
 		return fmt.Errorf("failed to update brew: %s", err)
 	}
@@ -77,6 +79,7 @@ func (r *Requirement) installBrew(brew string, formula string) error {
 	c.Stdin = os.Stdin
 	c.Stdout = io.Discard
 	c.Stderr = io.Discard
+	util.ProcessSetup(c)
 	return c.Run()
 }
 
@@ -88,6 +91,7 @@ func (r *Requirement) TryInstall(ctx TemplateContext) error {
 			c.Stdin = os.Stdin
 			c.Stdout = io.Discard
 			c.Stderr = io.Discard
+			util.ProcessSetup(c)
 			return c.Run()
 		}
 	}
@@ -117,6 +121,7 @@ func (r *Requirement) Matches(ctx TemplateContext) bool {
 	if command, ok := r.hasCommand(r.Command); ok {
 		ctx.Logger.Debug("checking version of %s", command)
 		c := exec.Command(command, r.Args...)
+		util.ProcessSetup(c)
 		out, err := c.Output()
 		if err != nil {
 			return false

--- a/internal/util/process_nix.go
+++ b/internal/util/process_nix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package util
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func ProcessKill(cmd *exec.Cmd) {
+	syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+}
+
+func ProcessSetup(cmd *exec.Cmd) {
+	// set this process as the parent of the process group since it will likely span child processes
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}

--- a/internal/util/process_windows.go
+++ b/internal/util/process_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package util
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func ProcessKill(projectServerCmd *exec.Cmd) {
+	if projectServerCmd.Process != nil {
+		// Get the process handle using syscall
+		handle, err := syscall.OpenProcess(syscall.PROCESS_TERMINATE, false, uint32(projectServerCmd.Process.Pid))
+		if err == nil {
+			syscall.TerminateProcess(handle, 0)
+			syscall.CloseHandle(handle)
+		}
+		projectServerCmd.Process.Release()
+	}
+}
+
+func ProcessSetup(cmd *exec.Cmd) {
+	// set this process as the parent of the process group since it will likely span child processes
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: 0x08000000,
+		HideWindow:    true,
+	}
+}


### PR DESCRIPTION
Add initial pass at Windows Installer and fixes a few window MCP issues.

More to be done with windows installer in a followup:

- Signed Installer and binaries
- See if we can get the MCP server command to now show Console window