### PR TITLE
if the node_modules or .venv/lib directory are missing when bundling, force install

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -37,7 +37,7 @@ type BundleContext struct {
 
 func bundleJavascript(ctx BundleContext, dir string, outdir string, theproject *project.Project) error {
 
-	if ctx.Install {
+	if ctx.Install || !util.Exists(filepath.Join(dir, "node_modules")) {
 		var install *exec.Cmd
 		switch theproject.Bundler.Runtime {
 		case "nodejs":

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -150,7 +150,7 @@ var (
 
 func bundlePython(ctx BundleContext, dir string, outdir string, theproject *project.Project) error {
 
-	if ctx.Install {
+	if ctx.Install || !util.Exists(filepath.Join(dir, ".venv", "lib")) {
 		var install *exec.Cmd
 		switch theproject.Bundler.Runtime {
 		case "uv":


### PR DESCRIPTION
This can happen when you clone a new project and immediately try and deploy and don't run (bun or npm install or uv install)