### PR TITLE
Don't fail if MCP detection fails for any reason on create project

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -94,7 +94,7 @@ Examples:
   agentuity mcp list`,
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := env.NewLogger(cmd)
-		detected, err := mcp.Detect(true)
+		detected, err := mcp.Detect(logger, true)
 		if err != nil {
 			logger.Fatal("%s", err)
 		}

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -283,9 +283,9 @@ Examples:
 
 		if tui.HasTTY {
 			// handle MCP server installation
-			detected, err := mcp.Detect(true)
+			detected, err := mcp.Detect(logger, true)
 			if err != nil {
-				logger.Fatal("%s", err)
+				logger.Error("failed to detect MCP clients: %s", err)
 			}
 			if len(detected) > 0 {
 				var clients []string

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -102,7 +102,7 @@ func loadConfig(path string) (*MCPConfig, error) {
 var mcpClientConfigs []MCPClientConfig
 
 // Detect detects the MCP clients that are installed and returns an array of MCP client names found.
-func Detect(all bool) ([]MCPClientConfig, error) {
+func Detect(logger logger.Logger, all bool) ([]MCPClientConfig, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
@@ -158,7 +158,8 @@ func Detect(all bool) ([]MCPClientConfig, error) {
 		if util.Exists(config.ConfigLocation) {
 			mcpconfig, err = loadConfig(config.ConfigLocation)
 			if err != nil {
-				return nil, err
+				logger.Error("failed to load MCP config for %s: %s", config.Name, err)
+				return nil, nil
 			}
 			if _, ok := mcpconfig.MCPServers[agentuityToolName]; ok {
 				config.Detected = true
@@ -173,7 +174,7 @@ func Detect(all bool) ([]MCPClientConfig, error) {
 // Install installs the agentuity tool for the given command and args.
 // It will install the tool for each MCP client config that is detected and not already installed.
 func Install(ctx context.Context, logger logger.Logger) error {
-	detected, err := Detect(false)
+	detected, err := Detect(logger, false)
 	if err != nil {
 		return err
 	}
@@ -243,7 +244,7 @@ func Install(ctx context.Context, logger logger.Logger) error {
 // Uninstall uninstalls the agentuity tool for the given command and args.
 // It will uninstall the tool for each MCP client config that is detected and not already uninstalled.
 func Uninstall(ctx context.Context, logger logger.Logger) error {
-	detected, err := Detect(false)
+	detected, err := Detect(logger, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9695f086-60bd-4c0e-91e5-25d4c3cf9488)

User is reporting this error when trying to create a new project. The log fails at the very beginning in the only FATAL log which is related to MCP detection. MCP detection shouldn't fail the project creation.