### PR TITLE
Project Name uniqueness check should be within project not any project in the users org

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -90,7 +90,7 @@ func ShowNewProjectImport(ctx context.Context, logger logger.Logger, cmd *cobra.
 	tui.WaitForAnyKey()
 	tui.ClearScreen()
 	orgId := promptForOrganization(ctx, logger, cmd, apiUrl, apikey)
-	name, description := promptForProjectDetail(ctx, logger, apiUrl, apikey, project.Name, project.Description)
+	name, description := promptForProjectDetail(ctx, logger, apiUrl, apikey, project.Name, project.Description, orgId)
 	project.Name = name
 	project.Description = description
 	var createWebhookAuth bool

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -131,10 +131,10 @@ func initProject(ctx context.Context, logger logger.Logger, args InitProjectArgs
 	return result
 }
 
-func promptForProjectDetail(ctx context.Context, logger logger.Logger, apiUrl, apikey string, name string, description string) (string, string) {
+func promptForProjectDetail(ctx context.Context, logger logger.Logger, apiUrl, apikey string, name string, description string, orgId string) (string, string) {
 	var nameOK bool
 	if name != "" {
-		if exists, err := project.ProjectWithNameExists(ctx, logger, apiUrl, apikey, name); err != nil {
+		if exists, err := project.ProjectWithNameExists(ctx, logger, apiUrl, apikey, orgId, name); err != nil {
 			errsystem.New(errsystem.ErrApiRequest, err, errsystem.WithContextMessage("Failed to check if project name exists")).ShowErrorAndExit()
 		} else if exists {
 			tui.ShowWarning("project %s already exists in this organization. please choose another name", name)
@@ -151,7 +151,7 @@ func promptForProjectDetail(ctx context.Context, logger logger.Logger, apiUrl, a
 					}
 				}
 			}
-			if exists, err := project.ProjectWithNameExists(ctx, logger, apiUrl, apikey, name); err != nil {
+			if exists, err := project.ProjectWithNameExists(ctx, logger, apiUrl, apikey, orgId, name); err != nil {
 				errsystem.New(errsystem.ErrApiRequest, err, errsystem.WithContextMessage("Failed to check if project name exists")).ShowErrorAndExit()
 			} else if exists {
 				return fmt.Errorf("project %s already exists in this organization. please choose another name", name)
@@ -402,7 +402,7 @@ Examples:
 						}
 					}
 				}
-				exists, err := project.ProjectWithNameExists(ctx, logger, apiUrl, apikey, name)
+				exists, err := project.ProjectWithNameExists(ctx, logger, apiUrl, apikey, orgId, name)
 				if err != nil {
 					return false, err
 				}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -257,11 +257,11 @@ type Response[T any] struct {
 
 type ProjectResponse = Response[ProjectData]
 
-func ProjectWithNameExists(ctx context.Context, logger logger.Logger, baseUrl string, token string, name string) (bool, error) {
+func ProjectWithNameExists(ctx context.Context, logger logger.Logger, baseUrl string, token string, orgId string, name string) (bool, error) {
 	client := util.NewAPIClient(ctx, logger, baseUrl, token)
 
 	var resp Response[bool]
-	if err := client.Do("GET", fmt.Sprintf("/cli/project/exists/%s", url.PathEscape(name)), nil, &resp); err != nil {
+	if err := client.Do("GET", fmt.Sprintf("/cli/project/exists/%s?orgId=%s", url.PathEscape(name), url.PathEscape(orgId)), nil, &resp); err != nil {
 		var apiErr *util.APIError
 		if errors.As(err, &apiErr) {
 			if apiErr.Status == http.StatusConflict {


### PR DESCRIPTION
Right now, we are checking project name uniqueness across all the user's organizations instead of just the organization that they are choosing.  We should only use the orgId they selected.