### PR TITLE
Update the dev help output to use the direct agent route instead of legacy route

### DIFF
--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -203,7 +203,7 @@ func displayLocalInstructions(port int, agents []project.AgentConfig, devModeUrl
 		sampleAgentID = agents[0].ID
 	}
 
-	curlCommand := fmt.Sprintf("curl -v http://localhost:%d/run/%s --json '{\"input\": \"Hello, world!\"}'", port, sampleAgentID)
+	curlCommand := fmt.Sprintf("curl -v http://localhost:%d/%s --json '{\"input\": \"Hello, world!\"}'", port, sampleAgentID)
 
 	fmt.Println()
 	fmt.Println(tui.Text("To interact with your agents locally, you can use:"))


### PR DESCRIPTION
*DO NOT MERGE*

This PR depends on release of the new JS SDK https://github.com/agentuity/sdk-js/pull/87