### PR TITLE
DevMode: when build failure after initial start, dont fail just print the error and continue

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -22,6 +22,8 @@ import (
 
 var Version = "dev"
 
+var ErrBuildFailed = fmt.Errorf("build failed")
+
 type AgentConfig struct {
 	ID       string `json:"id"`
 	Name     string `json:"name"`
@@ -35,6 +37,7 @@ type BundleContext struct {
 	Production bool
 	Install    bool
 	CI         bool
+	DevMode    bool
 }
 
 func bundleJavascript(ctx BundleContext, dir string, outdir string, theproject *project.Project) error {
@@ -155,6 +158,10 @@ func bundleJavascript(ctx BundleContext, dir string, outdir string, theproject *
 		for _, err := range result.Errors {
 			formattedError := formatESBuildError(dir, err)
 			fmt.Println(formattedError)
+		}
+
+		if ctx.DevMode {
+			return ErrBuildFailed
 		}
 
 		os.Exit(2)


### PR DESCRIPTION
An JS error during hot reload should just print the error (which is does) and not exit.