### PR TITLE
Make sure agent create has a reference to the template so we can reference it in interpolation

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -305,6 +305,11 @@ var agentCreateCmd = &cobra.Command{
 				errsystem.New(errsystem.ErrInvalidConfiguration, err, errsystem.WithAttributes(map[string]any{"identifier": theproject.Project.Bundler.Identifier})).ShowErrorAndExit()
 			}
 
+			template, err := templates.LoadTemplateForRuntime(context.Background(), tmpdir, theproject.Project.Bundler.Identifier)
+			if err != nil {
+				errsystem.New(errsystem.ErrInvalidConfiguration, err, errsystem.WithAttributes(map[string]any{"identifier": theproject.Project.Bundler.Identifier})).ShowErrorAndExit()
+			}
+
 			if err := rules.NewAgent(templates.TemplateContext{
 				Logger:           logger,
 				AgentName:        name,
@@ -313,6 +318,7 @@ var agentCreateCmd = &cobra.Command{
 				AgentDescription: description,
 				ProjectDir:       theproject.Dir,
 				TemplateDir:      tmpdir,
+				Template:         template,
 				AgentuityCommand: getAgentuityCommand(),
 			}); err != nil {
 				errsystem.New(errsystem.ErrApiRequest, err, errsystem.WithAttributes(map[string]any{"name": name})).ShowErrorAndExit()

--- a/internal/templates/template.go
+++ b/internal/templates/template.go
@@ -159,6 +159,9 @@ func (t *TemplateRules) NewProject(ctx TemplateContext) error {
 }
 
 func (t *TemplateRules) NewAgent(ctx TemplateContext) error {
+	if ctx.Template == nil {
+		return fmt.Errorf("template is nil and is required")
+	}
 	for _, step := range t.NewAgentSteps.Steps {
 		if command, ok := resolveStep(ctx, step); ok {
 			if err := command.Run(ctx); err != nil {

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -392,6 +392,19 @@ func LoadTemplates(ctx context.Context, dir string, custom bool) (Templates, err
 	return LoadTemplatesFromGithub(ctx, dir)
 }
 
+func LoadTemplateForRuntime(ctx context.Context, dir string, runtime string) (*Template, error) {
+	templates, err := LoadTemplates(ctx, dir, false)
+	if err != nil {
+		return nil, err
+	}
+	for _, template := range templates {
+		if template.Identifier == runtime {
+			return &template, nil
+		}
+	}
+	return nil, fmt.Errorf("template for runtime %s not found", runtime)
+}
+
 func LoadLanguageTemplates(ctx context.Context, dir string, runtime string) (LanguageTemplates, error) {
 	filename := filepath.Join(dir, runtime, "templates.yaml")
 	reader, err := getEmbeddedFile(filename)


### PR DESCRIPTION
Now that interpolate needs to know information about the runtime, we need to ensure the template is set when creating a new agent.