### PR TITLE
Dont call close handler if conn is nil

### DIFF
--- a/internal/dev/websocket.go
+++ b/internal/dev/websocket.go
@@ -373,10 +373,12 @@ func (c *Websocket) SendMessage(logger logger.Logger, msg Message) error {
 
 func (c *Websocket) Close() error {
 	c.SendMessage(c.logger, NewCloseMessage(uuid.New().String(), c.Project.Project.ProjectId))
-	closeHandler := c.conn.CloseHandler()
-	if err := closeHandler(1000, "User requested shutdown"); err != nil {
-		c.logger.Error("failed to close connection: %s", err)
-		return err
+	if c.conn != nil {
+		closeHandler := c.conn.CloseHandler()
+		if err := closeHandler(1000, "User requested shutdown"); err != nil {
+			c.logger.Error("failed to close connection: %s", err)
+			return err
+		}
 	}
 	if c.cleanup != nil {
 		c.cleanup()


### PR DESCRIPTION
fixes:
```
[ERROR] failed to read message: websocket: close 1006 (abnormal closure): unexpected EOF
[INFO]  attempting to reconnect, retry 1 of 5
[ERROR] failed to reconnect: failed to dial: dial tcp [::1]:8787: connect: connection refused
[INFO]  live dev connection closed, shutting down
[DEBUG] server stopping
[INFO]  server stopped
[DEBUG] shutting down OpenTelemetry
[DEBUG] shut down OpenTelemetry
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x128 pc=0x104bb33cc]

goroutine 1 [running]:
github.com/gorilla/websocket.(*Conn).CloseHandler(...)
        C:/Users/runneradmin/go/pkg/mod/github.com/gorilla/websocket@v1.5.3/conn.go:1118
github.com/agentuity/cli/internal/dev.(*Websocket).Close(0x1400047c2c0)
        D:/a/cli/cli/internal/dev/websocket.go:376 +0x10c
github.com/agentuity/cli/cmd.init.func28(0x105a649e0, {0x105aa9fe0?, 0x4?, 0x104c7562e?})
        D:/a/cli/cli/cmd/dev.go:196 +0x1178
github.com/spf13/cobra.(*Command).execute(0x105a649e0, {0x105aa9fe0, 0x0, 0x0})
        C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1019 +0x810
github.com/spf13/cobra.(*Command).ExecuteC(0x105a66560)
        C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x350
github.com/spf13/cobra.(*Command).Execute(...)
        C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
github.com/agentuity/cli/cmd.Execute()
        D:/a/cli/cli/cmd/root.go:76 +0x24
main.main()
        D:/a/cli/cli/main.go:47 +0x21c
```