### PR TITLE
[AGENT-129] Multiple tags for a deployment

### DIFF
--- a/internal/mcp/deploy.go
+++ b/internal/mcp/deploy.go
@@ -7,7 +7,10 @@ import (
 )
 
 type DeployArguments struct {
-	Directory string `json:"directory" jsonschema:"required,description=The directory where the project is located"`
+	Directory   string   `json:"directory" jsonschema:"required,description=The directory where the project is located"`
+	Tags        []string `json:"tags,omitempty" jsonschema:"description=Tags to associate with this deployment"`
+	Description string   `json:"description,omitempty" jsonschema:"description=Description for the deployment tag(s)"`
+	Message     string   `json:"message,omitempty" jsonschema:"description=Message for the deployment tag(s)"`
 }
 
 func init() {
@@ -22,7 +25,17 @@ func init() {
 			if resp := ensureProject(&c); resp != nil {
 				return resp, nil
 			}
-			result, err := execCommand(ctx, c.ProjectDir, "deploy", "--format", "json", "--dir", c.ProjectDir)
+			argsList := []string{"deploy", "--format", "json", "--dir", c.ProjectDir}
+			for _, tag := range args.Tags {
+				argsList = append(argsList, "--tag", tag)
+			}
+			if args.Description != "" {
+				argsList = append(argsList, "--description", args.Description)
+			}
+			if args.Message != "" {
+				argsList = append(argsList, "--message", args.Message)
+			}
+			result, err := execCommand(ctx, c.ProjectDir, argsList[0], argsList[1:]...)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/util/slice.go
+++ b/internal/util/slice.go
@@ -1,0 +1,24 @@
+package util
+
+func RemoveDuplicates[T comparable](slice []T) []T {
+	uniqueMap := make(map[T]bool)
+	uniqueSlice := []T{}
+	for _, item := range slice {
+		if !uniqueMap[item] {
+			uniqueMap[item] = true
+			uniqueSlice = append(uniqueSlice, item)
+		}
+	}
+	return uniqueSlice
+}
+
+func RemoveEmpty[T comparable](slice []T) []T {
+	var zero T
+	nonEmptySlice := []T{}
+	for _, item := range slice {
+		if item != zero {
+			nonEmptySlice = append(nonEmptySlice, item)
+		}
+	}
+	return nonEmptySlice
+}

--- a/internal/util/slice_test.go
+++ b/internal/util/slice_test.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRemoveDuplicates_String(t *testing.T) {
+	input := []string{"a", "b", "a", "c", "b", "d"}
+	want := []string{"a", "b", "c", "d"}
+	got := RemoveDuplicates(input)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("RemoveDuplicates(strings) = %v, want %v", got, want)
+	}
+}
+
+func TestRemoveDuplicates_Int(t *testing.T) {
+	input := []int{1, 2, 2, 3, 1, 4}
+	want := []int{1, 2, 3, 4}
+	got := RemoveDuplicates(input)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("RemoveDuplicates(ints) = %v, want %v", got, want)
+	}
+}
+
+func TestRemoveEmpty_String(t *testing.T) {
+	input := []string{"a", "", "b", "", "c"}
+	want := []string{"a", "b", "c"}
+	got := RemoveEmpty(input)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("RemoveEmpty(strings) = %v, want %v", got, want)
+	}
+}
+
+func TestRemoveEmpty_Int(t *testing.T) {
+	input := []int{0, 1, 2, 0, 3}
+	want := []int{1, 2, 3}
+	got := RemoveEmpty(input)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("RemoveEmpty(ints) = %v, want %v", got, want)
+	}
+}
+
+func TestRemoveDuplicates_AlreadyUnique(t *testing.T) {
+	input := []string{"x", "y", "z"}
+	want := []string{"x", "y", "z"}
+	got := RemoveDuplicates(input)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("RemoveDuplicates(already unique) = %v, want %v", got, want)
+	}
+}
+
+func TestRemoveEmpty_NoEmpty(t *testing.T) {
+	input := []int{1, 2, 3}
+	want := []int{1, 2, 3}
+	got := RemoveEmpty(input)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("RemoveEmpty(no empty) = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Closing previos PR to avoid confison #288 

With this change, you can pass in multiple tags to a deployment, a small description (message), and longer description 
```
--tag 'latest' --tag '0.0.1' --tag 'what-ever' --message 'fix issue with ai prompt' --description 'something much longer explaining exactly what happened"
```
These are all optional, if no tag is passed in, a tag called "latest" will be created