### PR TITLE
Devmode: fix issue when using short agentid wasn't going upstream

### DIFF
--- a/internal/dev/server.go
+++ b/internal/dev/server.go
@@ -297,6 +297,7 @@ func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
 		if agent.ID == agentId || strings.TrimLeft(agent.ID, "agent_") == agentId {
 			found = true
 			agentId = agent.ID
+			r.URL.Path = fmt.Sprintf("/%s", agentId) // in case we used the short version of the agent id
 			break
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of agent ID paths to ensure consistent recognition and processing, regardless of whether a full or shortened agent ID is used in the request URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->