### PR TITLE
Added better logging on startup, make sure we kill server if healthcheck fails, wait longer

### DIFF
--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -207,14 +207,17 @@ Examples:
 		}
 		defer watcher.Close(tuiLogger)
 
+		tuiLogger.Trace("starting project server")
 		if err := projectServerCmd.Start(); err != nil {
 			errsystem.New(errsystem.ErrInvalidConfiguration, err, errsystem.WithContextMessage(fmt.Sprintf("Failed to start project: %s", err))).ShowErrorAndExit()
 		}
 
 		pid = projectServerCmd.Process.Pid
+		tuiLogger.Trace("started project server with pid: %d", pid)
 
 		if err := server.HealthCheck(devModeUrl); err != nil {
 			tuiLogger.Error("failed to health check connection: %s", err)
+			dev.KillProjectServer(tuiLogger, projectServerCmd, pid)
 			ui.Close(true)
 			return
 		}

--- a/internal/dev/server.go
+++ b/internal/dev/server.go
@@ -458,9 +458,9 @@ func (s *Server) getWelcome(ctx context.Context, port int) (map[string]Welcome, 
 func (s *Server) HealthCheck(devModeUrl string) error {
 	started := time.Now()
 	var i int
-	for time.Since(started) < 15*time.Second {
+	for time.Since(started) < 30*time.Second {
 		i++
-		s.logger.Trace("health check request: %s", fmt.Sprintf("%s/_health", devModeUrl))
+		s.logger.Trace("health check request [#%d (%s)]: %s", i, time.Since(started), fmt.Sprintf("%s/_health", devModeUrl))
 		req, err := http.NewRequestWithContext(s.ctx, "GET", fmt.Sprintf("%s/_health", devModeUrl), nil)
 		if err != nil {
 			return fmt.Errorf("failed to create health check request: %w", err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced logging during the project server startup process, providing more detailed trace messages and process information.
  - Increased the health check retry duration for the server, allowing up to 30 seconds for successful startup.
  - Improved trace output for health check attempts, including attempt count and elapsed time.
  - Ensured the server process is properly terminated if the health check fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->