### PR TITLE
DevMode: Allow the API to return a preferred server

### DIFF
--- a/internal/dev/server.go
+++ b/internal/dev/server.go
@@ -249,7 +249,7 @@ func (s *Server) connect(initial bool) {
 	s.connectionFailed = time.Time{}
 	s.reconnectMutex.Unlock()
 
-	s.logger.Debug("connection established to %s", s.serverAddr)
+	s.logger.Debug("connection established to %s", hostname)
 
 	// HTTP/2 server to accept proxied requests over the tunnel connection
 	h2s := &http2.Server{}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Hostname information is now included in server connection responses and used for TLS connections, improving flexibility when connecting to servers.
- **Bug Fixes**
  - Minor syntax correction to improve code reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->