### PR TITLE
Deploy: fixed error missing file on zip

### DIFF
--- a/internal/util/io.go
+++ b/internal/util/io.go
@@ -123,6 +123,9 @@ func ZipDir(dir string, outfilename string, opts ...ZipDirCallbackMatcher) error
 		if err != nil {
 			return fmt.Errorf("error getting relative path: %s. %w", file, err)
 		}
+		if !Exists(file) {
+			continue
+		}
 		rf, err := os.Open(file)
 		if err != nil {
 			return fmt.Errorf("error opening file: %s. %w", file, err)

--- a/internal/util/io.go
+++ b/internal/util/io.go
@@ -126,20 +126,14 @@ func ZipDir(dir string, outfilename string, opts ...ZipDirCallbackMatcher) error
 		if !Exists(file) {
 			continue
 		}
-		rf, err := os.Open(file)
-		if err != nil {
-			return fmt.Errorf("error opening file: %s. %w", file, err)
-		}
-		defer rf.Close()
 		if len(opts) > 0 {
-			fi, err := rf.Stat()
+			fi, err := os.Stat(file)
 			if err != nil {
 				return fmt.Errorf("error getting file info: %s. %w", file, err)
 			}
 			var notok bool
 			for _, opt := range opts {
 				if !opt(fn, fi) {
-					rf.Close()
 					notok = true
 					break
 				}
@@ -148,6 +142,11 @@ func ZipDir(dir string, outfilename string, opts ...ZipDirCallbackMatcher) error
 				continue
 			}
 		}
+		rf, err := os.Open(file)
+		if err != nil {
+			return fmt.Errorf("error opening file: %s. %w", file, err)
+		}
+		defer rf.Close()
 		w, err := zw.Create(fn)
 		if err != nil {
 			return fmt.Errorf("error creating file: %s. %w", fn, err)


### PR DESCRIPTION
got this error deploying a python langchain (although unrelated to framework):

```
╭──────────────────────────────────────────────────────────────────────────────────╮
│                                                                                  │
│ ☹ Error Detected                                                                 │
│                                                                                  │
│ Failed to create zip file                                                        │
│                                                                                  │
│ Error:    error opening file:                                                    │
│ /Users/jhaynie/tmp/demo/testlangchain/.venv/bin/python. open                     │
│ /Users/jhaynie/tmp/demo/testlangchain/.venv/bin/python: no such                  │
│ file or directory                                                                │
│                                                                                  │
│ Code:     CLI-0017                                                               │
│ ID:       39a73280-73ce-4899-9a51-ca7f0995ab87                                   │
│ Doc:      https://agentuity.dev/errors/CLI-0017                                  │
│ Help:     https://discord.gg/agentuity                                           │
│           support@agentuity.com                                                  │
│                                                                                  │
│                                                                                  │
╰──────────────────────────────────────────────────────────────────────────────────╯
```

stack is:

```
goroutine 190 [running]:
runtime/debug.Stack()
	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.linux-amd64/src/runtime/debug/stack.go:26 +0x64
github.com/agentuity/cli/internal/errsystem.(*errSystem).ShowErrorAndExit(0x140000ec0e0)
	/home/runner/_work/cli/cli/internal/errsystem/console.go:103 +0x80
github.com/agentuity/cli/cmd.init.func36.2()
	/home/runner/_work/cli/cli/cmd/cloud.go:482 +0x1f4
github.com/agentuity/go-common/tui.ShowSpinner.func1()
	/home/runner/go/pkg/mod/github.com/agentuity/go-common@v1.0.64/tui/spinner.go:31 +0x54
github.com/agentuity/go-common/tui.ShowSpinner.(*Spinner).Action.func2({0x14000509718?, 0x104cf6084?})
	/home/runner/go/pkg/mod/github.com/charmbracelet/huh/spinner@v0.0.0-20250313000648-36d9de46d64e/spinner.go:74 +0x24
github.com/charmbracelet/huh/spinner.(*Spinner).Init.func1()
	/home/runner/go/pkg/mod/github.com/charmbracelet/huh/spinner@v0.0.0-20250313000648-36d9de46d64e/spinner.go:131 +0x34
github.com/charmbracelet/bubbletea.(*Program).handleCommands.func1.1()
	/home/runner/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.4/tea.go:352 +0x64
created by github.com/charmbracelet/bubbletea.(*Program).handleCommands.func1 in goroutine 187
	/home/runner/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.4/tea.go:346 +0x10c
```


That whole directory is ignored but was still trying to open the file.

So we can check for exists before continuing.  And as a slight performance optimization, we should check to see if we're ignoring before even trying to open the file.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved file handling efficiency and resource management when processing files for zipping, resulting in better performance and reliability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->