### PR TITLE
Need to use the changed directory when using last known project

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -641,6 +641,7 @@ func ResolveProjectDir(logger logger.Logger, cmd *cobra.Command, required bool) 
 		dir = viper.GetString("preferences.project_dir")
 		if ProjectExists(dir) {
 			tui.ShowWarning("Using your last used project directory (%s). You should change into the correct directory or use the --dir flag.", dir)
+			os.Chdir(dir)
 			return dir
 		}
 		tui.ShowBanner("Agentuity Project Not Found", "No Agentuity project file not found in the directory "+abs+"\n\nMake sure you are in an Agentuity project directory or use the --dir flag to specify a project directory.", false)


### PR DESCRIPTION
this can have the effect of using one directory for bundle and another for deploy which can cause a mismatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured the app automatically switches to the last used project directory if the current one is not found, improving reliability when accessing projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->