### PR TITLE
[AGENT-232] Fix issue with python project name

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -391,8 +391,8 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 	fileAgents := make(map[string]project.AgentConfig)
 	fileAgentsByID := make(map[string]project.AgentConfig)
 	for _, agent := range theproject.Project.Agents {
-		projectName := theproject.Project.SafeFilename()
-		fileAgents[projectName] = agent
+		key := util.SafeProjectFilename(agent.Name, theproject.Project.IsPython())
+		fileAgents[key] = agent
 		fileAgentsByID[agent.ID] = agent
 	}
 
@@ -402,11 +402,11 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 	// perform the reconcilation
 	state := make(map[string]agentListState)
 	for _, agent := range remoteAgents {
-		projectName := theproject.Project.SafeFilename()
-		state[projectName] = agentListState{
+		key := util.SafeProjectFilename(agent.Name, theproject.Project.IsPython())
+		state[key] = agentListState{
 			Agent:       &agent,
-			Filename:    filepath.Join(agentSrcDir, projectName, agentFilename),
-			FoundLocal:  util.Exists(filepath.Join(agentSrcDir, projectName, agentFilename)),
+			Filename:    filepath.Join(agentSrcDir, key, agentFilename),
+			FoundLocal:  util.Exists(filepath.Join(agentSrcDir, key, agentFilename)),
 			FoundRemote: true,
 		}
 	}
@@ -416,14 +416,14 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 	}
 	for _, filename := range localAgents {
 		agentName := filepath.Base(filepath.Dir(filename))
-		projectName := theproject.Project.SafeFilename()
+		key := util.SafeProjectFilename(agentName, theproject.Project.IsPython())
 		// var found bool
 		// for _, agent := range remoteAgents {
 		// 	if localAgent, ok := fileAgentsByID[agent.ID]; ok {
 		// 		if localAgent.Name == agentName {
 		// 			oldkey := normalAgentName(agent.Name)
 		// 			agent.Name = localAgent.Name
-		// 			state[projectName] = agentListState{
+		// 			state[key] = agentListState{
 		// 				Agent:       &agent,
 		// 				Filename:    filename,
 		// 				FoundLocal:  true,
@@ -441,8 +441,8 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 		// 	continue
 		// }
 		if filepath.Base(filename) == agentFilename {
-			if found, ok := state[projectName]; ok {
-				state[projectName] = agentListState{
+			if found, ok := state[key]; ok {
+				state[key] = agentListState{
 					Agent:       found.Agent,
 					Filename:    filename,
 					FoundLocal:  true,
@@ -450,15 +450,15 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 				}
 				continue
 			}
-			if a, ok := fileAgents[projectName]; ok {
-				state[projectName] = agentListState{
+			if a, ok := fileAgents[key]; ok {
+				state[key] = agentListState{
 					Agent:       &agent.Agent{Name: a.Name, ID: a.ID, Description: a.Description},
 					Filename:    filename,
 					FoundLocal:  true,
 					FoundRemote: true,
 				}
 			} else {
-				state[projectName] = agentListState{
+				state[key] = agentListState{
 					Agent:       &agent.Agent{Name: agentName},
 					Filename:    filename,
 					FoundLocal:  true,

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -369,6 +369,10 @@ func getAgentList(logger logger.Logger, apiUrl string, apikey string, project pr
 	return remoteAgents, err
 }
 
+func normalAgentName(name string, isPython bool) string {
+	return util.SafeProjectFilename(strings.ToLower(name), isPython)
+}
+
 func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string, apikey string, theproject project.ProjectContext) ([]string, map[string]agentListState) {
 	remoteAgents, err := getAgentList(logger, apiUrl, apikey, theproject)
 	if err != nil {
@@ -391,7 +395,7 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 	fileAgents := make(map[string]project.AgentConfig)
 	fileAgentsByID := make(map[string]project.AgentConfig)
 	for _, agent := range theproject.Project.Agents {
-		key := util.SafeProjectFilename(agent.Name, theproject.Project.IsPython())
+		key := normalAgentName(agent.Name, theproject.Project.IsPython())
 		fileAgents[key] = agent
 		fileAgentsByID[agent.ID] = agent
 	}
@@ -402,7 +406,7 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 	// perform the reconcilation
 	state := make(map[string]agentListState)
 	for _, agent := range remoteAgents {
-		key := util.SafeProjectFilename(agent.Name, theproject.Project.IsPython())
+		key := normalAgentName(agent.Name, theproject.Project.IsPython())
 		state[key] = agentListState{
 			Agent:       &agent,
 			Filename:    filepath.Join(agentSrcDir, key, agentFilename),
@@ -416,7 +420,7 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 	}
 	for _, filename := range localAgents {
 		agentName := filepath.Base(filepath.Dir(filename))
-		key := util.SafeProjectFilename(agentName, theproject.Project.IsPython())
+		key := normalAgentName(agentName, theproject.Project.IsPython())
 		// var found bool
 		// for _, agent := range remoteAgents {
 		// 	if localAgent, ok := fileAgentsByID[agent.ID]; ok {

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -154,7 +154,7 @@ Examples:
 			}
 			return nil
 		})
-		fp := filepath.Join(filepath.Dir(cfgFile), util.SafeFilename(name)+".yaml")
+		fp := filepath.Join(filepath.Dir(cfgFile), util.SafeProjectFilename(name, false)+".yaml")
 		os.WriteFile(fp, []byte(fmt.Sprintf(`name: "%s"`, name)+"\n"), 0644)
 	},
 }

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -481,7 +481,7 @@ Examples:
 				provider = resp.Provider
 			}
 		}
-		projectDir := filepath.Join(cwd, util.SafeFilename(name))
+		projectDir := filepath.Join(cwd, util.SafeProjectFilename(name, provider.Language == "python"))
 		dir, _ := cmd.Flags().GetString("dir")
 		if dir != "" {
 			absDir, err := filepath.Abs(dir)

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -336,11 +336,7 @@ func getAgents(theproject *project.Project, filename string) []AgentConfig {
 	var agents []AgentConfig
 	for _, agent := range theproject.Agents {
 		var agentfilename string
-		if theproject.Bundler.Language == "python" {
-			agentfilename = util.SafePythonFilename(agent.Name)
-		} else {
-			agentfilename = util.SafeFilename(agent.Name)
-		}
+		agentfilename = theproject.SafeFilename()
 		agents = append(agents, AgentConfig{
 			ID:       agent.ID,
 			Name:     agent.Name,

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -336,7 +336,7 @@ func getAgents(theproject *project.Project, filename string) []AgentConfig {
 	var agents []AgentConfig
 	for _, agent := range theproject.Agents {
 		var agentfilename string
-		agentfilename = theproject.SafeFilename()
+		agentfilename = util.SafeProjectFilename(agent.Name, theproject.IsPython())
 		agents = append(agents, AgentConfig{
 			ID:       agent.ID,
 			Name:     agent.Name,

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -158,7 +158,7 @@ func (p *Project) SafeFilename() string {
 }
 
 func (p *Project) IsPython() bool {
-	return p.Bundler.Language == "python"
+	return p.Bundler.Language == "python" || p.Bundler.Language == "py"
 }
 
 // Load will load the project from a file in the given directory.

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -153,6 +153,14 @@ type Project struct {
 	Agents      []AgentConfig `json:"agents" yaml:"agents" hc:"The agents that are part of this project"`
 }
 
+func (p *Project) SafeFilename() string {
+	return util.SafeProjectFilename(p.Name, p.IsPython())
+}
+
+func (p *Project) IsPython() bool {
+	return p.Bundler.Language == "python"
+}
+
 // Load will load the project from a file in the given directory.
 func (p *Project) Load(dir string) error {
 	fn := getFilename(dir)

--- a/internal/templates/steps.go
+++ b/internal/templates/steps.go
@@ -546,7 +546,7 @@ func resolveStep(ctx TemplateContext, step any) (Step, bool) {
 				}
 				var name string
 				if val, ok := kv["name"].(string); ok {
-					name = util.SafeFilename(ctx.Interpolate(val).(string))
+					name = util.SafeProjectFilename(ctx.Interpolate(val).(string), ctx.Template.Language == "python")
 				}
 				var version string
 				if val, ok := kv["version"].(string); ok {

--- a/internal/templates/template.go
+++ b/internal/templates/template.go
@@ -29,10 +29,7 @@ type TemplateContext struct {
 func funcTemplates(t *template.Template, isPython bool) *template.Template {
 	return t.Funcs(template.FuncMap{
 		"safe_filename": func(s string) string {
-			if isPython {
-				return util.SafePythonFilename(s)
-			}
-			return util.SafeFilename(s)
+			return util.SafeProjectFilename(s, isPython)
 		},
 	})
 }

--- a/internal/util/strings.go
+++ b/internal/util/strings.go
@@ -3,7 +3,6 @@ package util
 import (
 	"fmt"
 	"regexp"
-	"strings"
 )
 
 var safeNameTransformer = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
@@ -13,7 +12,6 @@ var removeStartingDashes = regexp.MustCompile(`^[-]+`)
 var removeEndingDashes = regexp.MustCompile(`[-]+$`)
 
 func SafeProjectFilename(name string, python bool) string {
-	name = strings.ToLower(name)
 	if python {
 		if beginsWithNumber.MatchString(name) {
 			name = beginsWithNumber.ReplaceAllString(name, "")

--- a/internal/util/strings.go
+++ b/internal/util/strings.go
@@ -11,22 +11,21 @@ var beginsWithNumber = regexp.MustCompile(`^[0-9]+`)
 var removeStartingDashes = regexp.MustCompile(`^[-]+`)
 var removeEndingDashes = regexp.MustCompile(`[-]+$`)
 
-func SafeFilename(name string) string {
+func SafeProjectFilename(name string, python bool) string {
+	if python {
+		if beginsWithNumber.MatchString(name) {
+			name = beginsWithNumber.ReplaceAllString(name, "")
+		}
+		name = safePythonNameTransformer.ReplaceAllString(name, "_")
+		if removeStartingDashes.MatchString(name) {
+			name = removeStartingDashes.ReplaceAllString(name, "")
+		}
+		if removeEndingDashes.MatchString(name) {
+			name = removeEndingDashes.ReplaceAllString(name, "")
+		}
+		return name
+	}
 	return safeNameTransformer.ReplaceAllString(name, "-")
-}
-
-func SafePythonFilename(name string) string {
-	if beginsWithNumber.MatchString(name) {
-		name = beginsWithNumber.ReplaceAllString(name, "")
-	}
-	name = safePythonNameTransformer.ReplaceAllString(name, "_")
-	if removeStartingDashes.MatchString(name) {
-		name = removeStartingDashes.ReplaceAllString(name, "")
-	}
-	if removeEndingDashes.MatchString(name) {
-		name = removeEndingDashes.ReplaceAllString(name, "")
-	}
-	return name
 }
 
 func Pluralize(count int, singular string, plural string) string {

--- a/internal/util/strings.go
+++ b/internal/util/strings.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 var safeNameTransformer = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
@@ -12,6 +13,7 @@ var removeStartingDashes = regexp.MustCompile(`^[-]+`)
 var removeEndingDashes = regexp.MustCompile(`[-]+$`)
 
 func SafeProjectFilename(name string, python bool) string {
+	name = strings.ToLower(name)
 	if python {
 		if beginsWithNumber.MatchString(name) {
 			name = beginsWithNumber.ReplaceAllString(name, "")

--- a/internal/util/strings_test.go
+++ b/internal/util/strings_test.go
@@ -7,30 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSafeFilename(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{"empty string", "", ""},
-		{"no special characters", "filename", "filename"},
-		{"with spaces", "file name", "file-name"},
-		{"with special characters", "file@#$%^&*()name", "file---------name"},
-		{"mixed case", "FileName", "FileName"},
-		{"with numbers", "file123name", "file123name"},
-		{"with underscores", "file_name", "file_name"},
-		{"with hyphens", "file-name", "file-name"},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			result := SafeFilename(test.input)
-			assert.Equal(t, test.expected, result)
-		})
-	}
-}
-
 func TestPluralize(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -99,7 +75,31 @@ func TestSafePythonFilename(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := SafePythonFilename(test.input)
+			result := SafeProjectFilename(test.input, true)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestSafeFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty string", "", ""},
+		{"no special characters", "filename", "filename"},
+		{"with spaces", "file name", "file-name"},
+		{"with special characters", "file@#$%^&*()name", "file---------name"},
+		{"mixed case", "FileName", "FileName"},
+		{"with numbers", "file123name", "file123name"},
+		{"with underscores", "file_name", "file_name"},
+		{"with hyphens", "file-name", "file-name"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := SafeProjectFilename(test.input, false)
 			assert.Equal(t, test.expected, result)
 		})
 	}


### PR DESCRIPTION
Added a new function `SafeFilename` to the project object, it's a shortcut to the old function in utils which was renamed to SafeProjectFilename. Having different names helps when global searching the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling of filenames and directory names to be context-aware of the project language, especially for Python projects.

- **Refactor**
  - Unified and simplified filename sanitization across the app, consolidating previous logic into a single approach for more consistent behavior.
  - Streamlined agent reconciliation and file path construction by using a consistent project-safe filename key.
  - Added utility methods to project entities for language detection and safe filename generation.

- **Bug Fixes**
  - Enhanced matching and reconciliation of agents and profiles by using a consistent, project-safe filename format.

- **Tests**
  - Updated tests to validate the new filename sanitization logic for both generic and Python-specific cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->