### PR TITLE
Cloned projects need an .env file

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -204,7 +204,7 @@ Examples:
 
 			if !context.NewProject {
 				action = func() {
-					projectData, err = theproject.GetProject(ctx, logger, apiUrl, token)
+					projectData, err = theproject.GetProject(ctx, logger, apiUrl, token, true, false)
 					if err != nil {
 						if err == project.ErrProjectNotFound {
 							return

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -87,7 +87,7 @@ Examples:
 				fmt.Fprintf(of, "%s=%s\n", k, v)
 			}
 			of.Close()
-			tui.ShowSuccess("Synchronized .env file from project at %s", filename)
+			tui.ShowSuccess("Synchronized project to .env file: %s", tui.Muted(filename))
 		}
 
 		orgId := project.OrgId

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
 	"github.com/agentuity/cli/internal/bundler"
+	"github.com/agentuity/cli/internal/deployer"
 	"github.com/agentuity/cli/internal/dev"
 	"github.com/agentuity/cli/internal/envutil"
 	"github.com/agentuity/cli/internal/errsystem"
@@ -61,12 +63,32 @@ Examples:
 			ShowNewProjectImport(ctx, log, cmd, theproject.APIURL, apiKey, projectId, theproject.Project, dir, false)
 		}
 
-		project, err := theproject.Project.GetProject(ctx, log, theproject.APIURL, apiKey)
+		project, err := theproject.Project.GetProject(ctx, log, theproject.APIURL, apiKey, false, true)
 		if err != nil {
-			errsystem.New(errsystem.ErrInvalidConfiguration, err, errsystem.WithUserMessage("Failed to validate project (%s) using the provided API key from the .env file in %s. This is most likely due to the API key being invalid or the project has been deleted.\n\nYou can import this project using the following command:\n\n"+tui.Command("project import"), theproject.Project.ProjectId, dir), errsystem.WithContextMessage(fmt.Sprintf("Failed to get project: %s", err))).ShowErrorAndExit()
+			errsystem.New(errsystem.ErrInvalidConfiguration, err, errsystem.WithUserMessage("Failed to validate project (%s). This is most likely due to the API key being invalid or the project has been deleted.\n\nYou can import this project using the following command:\n\n"+tui.Command("project import"), theproject.Project.ProjectId), errsystem.WithContextMessage(fmt.Sprintf("Failed to get project: %s", err))).ShowErrorAndExit()
 		}
 
-		_, project = envutil.ProcessEnvFiles(ctx, log, dir, theproject.Project, project, theproject.APIURL, apiKey, false)
+		var envfile *deployer.EnvFile
+
+		envfile, project = envutil.ProcessEnvFiles(ctx, log, dir, theproject.Project, project, theproject.APIURL, apiKey, false)
+
+		if envfile == nil {
+			// we don't have an env file so we need to create one since this likely means you have cloned a new project
+			filename := filepath.Join(dir, ".env")
+			of, err := os.Create(filename)
+			if err != nil {
+				errsystem.New(errsystem.ErrInvalidConfiguration, err, errsystem.WithContextMessage("Failed to create .env file")).ShowErrorAndExit()
+			}
+			defer of.Close()
+			for k, v := range project.Env {
+				fmt.Fprintf(of, "%s=%s\n", k, v)
+			}
+			for k, v := range project.Secrets {
+				fmt.Fprintf(of, "%s=%s\n", k, v)
+			}
+			of.Close()
+			tui.ShowSuccess("Synchronized .env file from project at %s", filename)
+		}
 
 		orgId := project.OrgId
 

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -274,7 +274,9 @@ Examples:
 		apiUrl := context.APIURL
 		apiKey := context.Token
 
-		projectData, err := theproject.GetProject(ctx, logger, apiUrl, apiKey)
+		mask, _ := cmd.Flags().GetBool("mask")
+
+		projectData, err := theproject.GetProject(ctx, logger, apiUrl, apiKey, mask, false)
 		if err != nil {
 			errsystem.New(errsystem.ErrApiRequest, err).ShowErrorAndExit()
 		}
@@ -348,7 +350,10 @@ Examples:
 		apiUrl := context.APIURL
 		apiKey := context.Token
 
-		projectData, err := theproject.GetProject(ctx, logger, apiUrl, apiKey)
+		mask, _ := cmd.Flags().GetBool("mask")
+		includeProjectKeys, _ := cmd.Flags().GetBool("include-project-keys")
+
+		projectData, err := theproject.GetProject(ctx, logger, apiUrl, apiKey, mask, includeProjectKeys)
 		if err != nil {
 			errsystem.New(errsystem.ErrApiRequest, err).ShowErrorAndExit()
 		}
@@ -412,7 +417,7 @@ Examples:
 		apiUrl := context.APIURL
 		apiKey := context.Token
 
-		projectData, err := theproject.GetProject(ctx, logger, apiUrl, apiKey)
+		projectData, err := theproject.GetProject(ctx, logger, apiUrl, apiKey, true, false)
 		if err != nil {
 			errsystem.New(errsystem.ErrApiRequest, err).ShowErrorAndExit()
 		}
@@ -537,5 +542,8 @@ func init() {
 
 	for _, cmd := range []*cobra.Command{envListCmd, envGetCmd} {
 		cmd.Flags().String("format", "text", "The format to use for the output. Can be either 'text' or 'json'")
+		cmd.Flags().Bool("mask", true, "Mask secrets in the output")
 	}
+
+	envListCmd.Flags().Bool("include-project-keys", false, "Include project keys in the output")
 }

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -373,14 +373,14 @@ func DeleteProjects(ctx context.Context, logger logger.Logger, baseUrl string, t
 	return resp.Data, nil
 }
 
-func (p *Project) GetProject(ctx context.Context, logger logger.Logger, baseUrl string, token string) (*ProjectData, error) {
+func (p *Project) GetProject(ctx context.Context, logger logger.Logger, baseUrl string, token string, shouldMask bool, includeProjectKeys bool) (*ProjectData, error) {
 	if p.ProjectId == "" {
 		return nil, ErrProjectNotFound
 	}
 	client := util.NewAPIClient(ctx, logger, baseUrl, token)
 
 	var projectResponse ProjectResponse
-	if err := client.Do("GET", fmt.Sprintf("/cli/project/%s", p.ProjectId), nil, &projectResponse); err != nil {
+	if err := client.Do("GET", fmt.Sprintf("/cli/project/%s?mask=%t&includeProjectKeys=%t", p.ProjectId, shouldMask, includeProjectKeys), nil, &projectResponse); err != nil {
 		var apiErr *util.APIError
 		if errors.As(err, &apiErr) {
 			if apiErr.Status == 404 {


### PR DESCRIPTION
- Import and then clone new project and you are missing .env file
- Also allow env list and get to be masked optionally and optionally include project keys in list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added options to mask secrets and include project keys when viewing environment variables.
  - Introduced new command-line flags to control secret masking and inclusion of project keys in environment variable commands.
  - Improved handling and automatic creation of `.env` files during development setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->