### PR TITLE
Filter out env and secrets that are internal

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -398,9 +398,21 @@ func (p *Project) GetProject(ctx context.Context, logger logger.Logger, baseUrl 
 func (p *Project) SetProjectEnv(ctx context.Context, logger logger.Logger, baseUrl string, token string, env map[string]string, secrets map[string]string) (*ProjectData, error) {
 	client := util.NewAPIClient(ctx, logger, baseUrl, token)
 	var projectResponse ProjectResponse
+	_env := make(map[string]string)
+	for k, v := range env {
+		if !strings.HasPrefix(k, "AGENTUITY_") {
+			_env[k] = v
+		}
+	}
+	_secrets := make(map[string]string)
+	for k, v := range secrets {
+		if !strings.HasPrefix(k, "AGENTUITY_") {
+			_secrets[k] = v
+		}
+	}
 	if err := client.Do("PUT", fmt.Sprintf("/cli/project/%s/env", p.ProjectId), map[string]any{
-		"env":     env,
-		"secrets": secrets,
+		"env":     _env,
+		"secrets": _secrets,
 	}, &projectResponse); err != nil {
 		return nil, fmt.Errorf("error setting project env: %w", err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Environment variables and secrets with keys starting with "AGENTUITY_" are now excluded when updating the project environment, preventing them from being sent in API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->