### PR TITLE
Fix issue with agent casing not being considered

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -457,7 +457,7 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 		// if found {
 		// 	continue
 		// }
-		if filepath.Base(filename) == agentFilename || filepath.Base(filename) == normalizedName {
+		if filepath.Base(filename) == agentFilename {
 			if found, ok := state[key]; ok {
 				state[key] = agentListState{
 					Agent:       found.Agent,

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -395,7 +395,7 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 	fileAgents := make(map[string]project.AgentConfig)
 	fileAgentsByID := make(map[string]project.AgentConfig)
 	for _, agent := range theproject.Project.Agents {
-		key := normalAgentName(agent.Name, theproject.Project.IsPython())
+		key := normalAgentName(agent.Name, theproject.Project.IsPython()) + agent.Name
 		fileAgents[key] = agent
 		fileAgentsByID[agent.ID] = agent
 	}
@@ -406,11 +406,12 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 	// perform the reconcilation
 	state := make(map[string]agentListState)
 	for _, agent := range remoteAgents {
-		key := normalAgentName(agent.Name, theproject.Project.IsPython())
+		normalizedName := normalAgentName(agent.Name, theproject.Project.IsPython())
+		key := normalizedName + agent.Name
 		state[key] = agentListState{
 			Agent:       &agent,
-			Filename:    filepath.Join(agentSrcDir, key, agentFilename),
-			FoundLocal:  util.Exists(filepath.Join(agentSrcDir, key, agentFilename)),
+			Filename:    filepath.Join(agentSrcDir, normalizedName, agentFilename),
+			FoundLocal:  util.Exists(filepath.Join(agentSrcDir, normalizedName, agentFilename)),
 			FoundRemote: true,
 		}
 	}
@@ -420,7 +421,7 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 	}
 	for _, filename := range localAgents {
 		agentName := filepath.Base(filepath.Dir(filename))
-		key := normalAgentName(agentName, theproject.Project.IsPython())
+		key := normalAgentName(agentName, theproject.Project.IsPython()) + agentName
 		// var found bool
 		// for _, agent := range remoteAgents {
 		// 	if localAgent, ok := fileAgentsByID[agent.ID]; ok {

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -408,11 +408,22 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 	for _, agent := range remoteAgents {
 		normalizedName := normalAgentName(agent.Name, theproject.Project.IsPython())
 		key := normalizedName + agent.Name
-		state[key] = agentListState{
-			Agent:       &agent,
-			Filename:    filepath.Join(agentSrcDir, normalizedName, agentFilename),
-			FoundLocal:  util.Exists(filepath.Join(agentSrcDir, normalizedName, agentFilename)),
-			FoundRemote: true,
+		filename1 := filepath.Join(agentSrcDir, normalizedName, agentFilename)
+		filename2 := filepath.Join(agentSrcDir, agent.Name, agentFilename)
+		if util.Exists(filename1) {
+			state[key] = agentListState{
+				Agent:       &agent,
+				Filename:    filename1,
+				FoundLocal:  true,
+				FoundRemote: true,
+			}
+		} else if util.Exists(filename2) {
+			state[key] = agentListState{
+				Agent:       &agent,
+				Filename:    filename2,
+				FoundLocal:  true,
+				FoundRemote: true,
+			}
 		}
 	}
 	localAgents, err := util.ListDir(agentSrcDir)
@@ -421,7 +432,8 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 	}
 	for _, filename := range localAgents {
 		agentName := filepath.Base(filepath.Dir(filename))
-		key := normalAgentName(agentName, theproject.Project.IsPython()) + agentName
+		normalizedName := normalAgentName(agentName, theproject.Project.IsPython())
+		key := normalizedName + agentName
 		// var found bool
 		// for _, agent := range remoteAgents {
 		// 	if localAgent, ok := fileAgentsByID[agent.ID]; ok {
@@ -445,7 +457,7 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 		// if found {
 		// 	continue
 		// }
-		if filepath.Base(filename) == agentFilename {
+		if filepath.Base(filename) == agentFilename || filepath.Base(filename) == normalizedName {
 			if found, ok := state[key]; ok {
 				state[key] = agentListState{
 					Agent:       found.Agent,


### PR DESCRIPTION
Two agents one named `orchestrator` and the other named `Orchestrator` but only the lowercased one shows up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accuracy of agent mapping and reconciliation, ensuring more reliable handling of agents with similar names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->