### PR TITLE
fix: prevent terminal cursor from disappearing after breaking change …

### DIFF
--- a/internal/bundler/upgrade.go
+++ b/internal/bundler/upgrade.go
@@ -240,16 +240,16 @@ func checkForBreakingChanges(ctx BundleContext, language string, runtime string)
 					if err := change.Callback(ctx); err != nil {
 						return err
 					}
-					os.Exit(1)
+					return fmt.Errorf("migration performed, please re-run the command")
 				} else {
 					return fmt.Errorf("migration required")
 				}
 			} else {
 				if tui.HasTTY && !ctx.DevMode {
 					tui.ShowBanner(change.Title, change.Message, true)
-					os.Exit(1)
+					return fmt.Errorf("breaking change migration required")
 				} else {
-					ctx.Logger.Fatal(change.Message)
+					return fmt.Errorf("%s", change.Message)
 				}
 			}
 		}


### PR DESCRIPTION
…error by returning error instead of os.Exit(1) in checkForBreakingChanges

We can't just quit in the middle of a UI process, we need to gracefully quit after cleaning up. Please dont call panic or os.Exit when we're in a UI session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved error handling by returning errors instead of immediately terminating the process when breaking changes or migrations are detected. This allows for better control and flexibility in managing such scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->