### PR TITLE
More normalized Python project naming

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -395,7 +395,7 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 	fileAgents := make(map[string]project.AgentConfig)
 	fileAgentsByID := make(map[string]project.AgentConfig)
 	for _, agent := range theproject.Project.Agents {
-		key := normalAgentName(agent.Name, theproject.Project.IsPython()) + agent.Name
+		key := normalAgentName(agent.Name, theproject.Project.IsPython())
 		fileAgents[key] = agent
 		fileAgentsByID[agent.ID] = agent
 	}
@@ -407,18 +407,17 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 	state := make(map[string]agentListState)
 	for _, agent := range remoteAgents {
 		normalizedName := normalAgentName(agent.Name, theproject.Project.IsPython())
-		key := normalizedName + agent.Name
 		filename1 := filepath.Join(agentSrcDir, normalizedName, agentFilename)
 		filename2 := filepath.Join(agentSrcDir, agent.Name, agentFilename)
 		if util.Exists(filename1) {
-			state[key] = agentListState{
+			state[normalizedName] = agentListState{
 				Agent:       &agent,
 				Filename:    filename1,
 				FoundLocal:  true,
 				FoundRemote: true,
 			}
 		} else if util.Exists(filename2) {
-			state[key] = agentListState{
+			state[normalizedName] = agentListState{
 				Agent:       &agent,
 				Filename:    filename2,
 				FoundLocal:  true,
@@ -433,7 +432,7 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 	for _, filename := range localAgents {
 		agentName := filepath.Base(filepath.Dir(filename))
 		normalizedName := normalAgentName(agentName, theproject.Project.IsPython())
-		key := normalizedName + agentName
+		key := normalizedName
 		// var found bool
 		// for _, agent := range remoteAgents {
 		// 	if localAgent, ok := fileAgentsByID[agent.ID]; ok {

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -395,10 +395,16 @@ func reconcileAgentList(logger logger.Logger, cmd *cobra.Command, apiUrl string,
 	fileAgents := make(map[string]project.AgentConfig)
 	fileAgentsByID := make(map[string]project.AgentConfig)
 	for _, agent := range theproject.Project.Agents {
-		key := normalAgentName(agent.Name, theproject.Project.IsPython())
-		fileAgents[key] = agent
-		fileAgentsByID[agent.ID] = agent
-	}
+        key := normalAgentName(agent.Name, theproject.Project.IsPython())
+        if existing, ok := fileAgents[key]; ok {
+            logger.Warn(
+                "agent name collision: %q and %q normalize to %q; keeping first entry",
+                existing.Name, agent.Name, key,
+            )
+            continue
+        }
+        fileAgents[key] = agent
+        fileAgentsByID[agent.ID] = agent
 
 	agentFilename := rules.Filename
 	agentSrcDir := filepath.Join(theproject.Dir, theproject.Project.Bundler.AgentConfig.Dir)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized agent identification by using only the normalized agent name for internal processing, resulting in more consistent agent handling. No visible changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->