### PR TITLE
Add more flexible ignore matching for full ignore rule

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -148,6 +148,7 @@ func createProjectIgnoreRules(dir string, theproject *project.Project) *ignore.R
 				errsystem.WithContextMessage(fmt.Sprintf("Error adding project ignore rule: %s. %s", rule, err))).ShowErrorAndExit()
 		}
 	}
+
 	return rules
 }
 

--- a/internal/ignore/rules_test.go
+++ b/internal/ignore/rules_test.go
@@ -37,3 +37,57 @@ func TestRules(t *testing.T) {
 	assert.True(t, rules.Ignore("/Users/foobar/example/src/__test__/test_bar.py", nil))
 	assert.True(t, rules.Ignore("/Users/foobar/example/.agentuity-12345", nil))
 }
+
+func TestNegateRules(t *testing.T) {
+	rules := Empty()
+	rules.AddDefaults()
+	rules.Add("!**/foo.py")
+	assert.False(t, rules.Ignore("/Users/foobar/example/src/foo.py", nil))
+	assert.False(t, rules.Ignore("foo.py", nil))
+	assert.True(t, rules.Ignore("bar.py", nil))
+}
+
+func TestFullWildcardRules(t *testing.T) {
+	rules := Empty()
+	rules.AddDefaults()
+	rules.Add("**/*")
+	rules.Add("!.agentuity/**")
+	rules.Add("!agentuity.yaml")
+	assert.False(t, rules.Ignore(".agentuity/foo.py", nil))
+	assert.False(t, rules.Ignore("agentuity.yaml", nil))
+	assert.True(t, rules.Ignore("bar.py", nil))
+}
+
+func TestFullWildcardRulesAfter(t *testing.T) {
+	rules := Empty()
+	rules.AddDefaults()
+	rules.Add("!.agentuity/**")
+	rules.Add("!agentuity.yaml")
+	rules.Add("**/*")
+	assert.False(t, rules.Ignore(".agentuity/foo.py", nil))
+	assert.False(t, rules.Ignore("agentuity.yaml", nil))
+	assert.True(t, rules.Ignore("bar.py", nil))
+}
+
+func TestFullWildcardRulesBetween(t *testing.T) {
+	rules := Empty()
+	rules.AddDefaults()
+	rules.Add("!.agentuity/**")
+	rules.Add("**/*")
+	rules.Add("!agentuity.yaml")
+	assert.False(t, rules.Ignore(".agentuity/foo.py", nil))
+	assert.False(t, rules.Ignore("agentuity.yaml", nil))
+	assert.True(t, rules.Ignore("bar.py", nil))
+}
+
+func TestFullWildcardRulesFilteredOut(t *testing.T) {
+	rules := Empty()
+	rules.AddDefaults()
+	rules.Add("agentuity.yaml")
+	rules.Add("!.agentuity/**")
+	rules.Add("**/*")
+	rules.Add("!agentuity.yaml")
+	assert.False(t, rules.Ignore(".agentuity/foo.py", nil))
+	assert.False(t, rules.Ignore("agentuity.yaml", nil))
+	assert.True(t, rules.Ignore("bar.py", nil))
+}


### PR DESCRIPTION
For bundling, we aren't ignore enough files with the rules we have. In a JS bundle case, we can pretty much exclude _everything_ except the `agentuity.yaml` and the `.agentuity` directory to keep things as slim as possible. This will enable the ability to change the templates to be more aggressive in ignoring files.

We need to roll this out (and force upgrade) before we can roll out the [template changes](https://github.com/agentuity/templates/pull/39).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved file ignore rules to support a "full wildcard" pattern, allowing all files to be ignored by default and selectively included using negated rules.
- **Bug Fixes**
  - Enhanced handling of negated and wildcard ignore patterns for more flexible file inclusion and exclusion.
- **Tests**
  - Added comprehensive tests to verify correct behavior of negated and wildcard ignore rules in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->