### PR TITLE
Fix regression in hot reload for new bun/node templates

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -127,7 +127,7 @@ var envTemplateFileNames = []string{".env.example", ".env.template"}
 var border = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Padding(1).BorderForeground(lipgloss.AdaptiveColor{Light: "#999999", Dark: "#999999"})
 var redDiff = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#990000", Dark: "#EE0000"})
 
-func createProjectIgnoreRules(dir string, theproject *project.Project) *ignore.Rules {
+func createProjectIgnoreRules(dir string, theproject *project.Project, skipProjectIgnore bool) *ignore.Rules {
 	// load up any gitignore files
 	gitignore := filepath.Join(dir, ignore.Ignore)
 	rules := ignore.Empty()
@@ -140,6 +140,10 @@ func createProjectIgnoreRules(dir string, theproject *project.Project) *ignore.R
 		rules = r
 	}
 	rules.AddDefaults()
+
+	if skipProjectIgnore {
+		return rules
+	}
 
 	// add any provider specific ignore rules
 	for _, rule := range theproject.Bundler.Ignore {
@@ -469,7 +473,7 @@ Examples:
 			logger.Debug("saved project with updated Agents")
 		}
 
-		rules := createProjectIgnoreRules(dir, theproject)
+		rules := createProjectIgnoreRules(dir, theproject, false)
 
 		// create a temp file we're going to use for zip and upload
 		tmpfile, err := os.CreateTemp("", "agentuity-deploy-*.zip")

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -207,7 +207,7 @@ Examples:
 			}
 		}
 
-		rules := createProjectIgnoreRules(dir, theproject.Project)
+		rules := createProjectIgnoreRules(dir, theproject.Project, true)
 
 		// Watch for changes
 		watcher, err := dev.NewWatcher(log, dir, rules, func(path string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -170,8 +170,10 @@ func initConfig() {
 }
 
 func initScreenWithLogo() {
-	tui.ClearScreen()
-	tui.Logo()
+	if tui.HasTTY {
+		tui.ClearScreen()
+		tui.Logo()
+	}
 }
 
 func createPromptHelper() deployer.PromptHelpers {

--- a/internal/ignore/rules.go
+++ b/internal/ignore/rules.go
@@ -92,6 +92,7 @@ func (r *Rules) AddDefaults() {
 	r.parseRule("**/.cursor/**")
 	r.parseRule("**/.vscode/**")
 	r.parseRule("**/.agentuity-*")
+	r.parseRule("**/biome.json")
 }
 
 // Add a rule to the ignore set.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Files named `biome.json` are now automatically ignored by default during relevant operations.

- **Improvements**
	- The application now avoids clearing the screen and displaying the logo in non-interactive or non-terminal environments, improving compatibility with automated workflows.

- **Bug Fixes**
	- Adjusted ignore rules handling to ensure project-specific ignore patterns can be conditionally skipped or included as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->