### PR TITLE
When running dev mode, make sure we have a .env.development file

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -262,7 +262,7 @@ Examples:
 				force = true
 			}
 			// check to see if we have any env vars that are not in the project
-			envFile, projectData = envutil.ProcessEnvFiles(ctx, logger, dir, theproject, projectData, apiUrl, token, force)
+			envFile, projectData = envutil.ProcessEnvFiles(ctx, logger, dir, theproject, projectData, apiUrl, token, force, false)
 
 			if tui.HasTTY {
 				_, localIssues, remoteIssues, err := buildAgentTree(keys, state, context)

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -70,7 +70,7 @@ Examples:
 
 		var envfile *deployer.EnvFile
 
-		envfile, project = envutil.ProcessEnvFiles(ctx, log, dir, theproject.Project, project, theproject.APIURL, apiKey, false)
+		envfile, project = envutil.ProcessEnvFiles(ctx, log, dir, theproject.Project, project, theproject.APIURL, apiKey, false, true)
 
 		if envfile == nil {
 			// we don't have an env file so we need to create one since this likely means you have cloned a new project

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -329,15 +329,15 @@ Examples:
 				fmt.Println(tui.Text("• ") + tui.Command(" project import") + tui.Text(" - Import this project to your organization"))
 				fmt.Println(tui.Text("• ") + tui.Command(" deploy") + tui.Text(" - Deploy this project"))
 				fmt.Println()
-				
+
 				continueAnyway := tui.Ask(logger, "Are you sure you want to create a new project here?", false)
-				
+
 				if !continueAnyway {
 					fmt.Println()
 					tui.ShowSuccess("No worries! Use one of the commands above to work with your existing project.")
 					os.Exit(0)
 				}
-				
+
 				fmt.Println()
 				tui.ShowWarning("Continuing with new project creation...")
 				fmt.Println()
@@ -899,7 +899,7 @@ Examples:
 		if !tui.HasTTY {
 			force = true
 		}
-		_, _ = envutil.ProcessEnvFiles(ctx, logger, context.Dir, context.Project, nil, context.APIURL, context.Token, force)
+		_, _ = envutil.ProcessEnvFiles(ctx, logger, context.Dir, context.Project, nil, context.APIURL, context.Token, force, false)
 
 	},
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - During local development, a `.env.development` file is now automatically created if it does not exist, ensuring consistent environment setup.
- **Bug Fixes**
  - Improved handling of environment files during project import and deployment to better distinguish between development and production environments.
- **Style**
  - Minor cleanup of extraneous blank lines in project creation prompts for a neater interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->