### PR TITLE
[GITHUB-338] Do not create a git repo if we’re already in a git repo

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -638,15 +638,17 @@ Examples:
 		if !gitInfo.IsRepo {
 			projectGitFlow(ctx, provider, tmplContext, githubAction)
 		} else {
-			// Check if the found git repo is in a parent directory
-			// If so, do NOT run projectGitFlow (do not create a sub-repo)
-			// If the found .git is in projectDir, it's safe to run projectGitFlow
-			parentGitInfo, _ := deployer.GetGitInfo(logger, projectDir)
-			if parentGitInfo != nil && parentGitInfo.IsRepo {
-				// There is a .git in projectDir, so it's safe to run projectGitFlow
+			// Check if there's a .git directory directly in the project directory
+			// If so, it's safe to run projectGitFlow; otherwise, we're in a parent git repo
+			projectDirGitInfo, err := deployer.GetGitInfo(logger, projectDir)
+			if err != nil {
+				logger.Debug("failed to get git info for project directory: %s", err)
+			}
+			if projectDirGitInfo != nil && projectDirGitInfo.IsRepo {
+				// There is a .git directly in projectDir, so it's safe to run projectGitFlow
 				projectGitFlow(ctx, provider, tmplContext, githubAction)
 			} else {
-				// There is a parent git repo, do not create a sub-repo
+				// We're inside a parent git repository, do not create a nested repo
 				logger.Info("Project is inside an existing git repository; not creating a new git repo.")
 			}
 		}

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -633,8 +633,22 @@ Examples:
 		}
 		logger.Debug("git info: %+v", gitInfo)
 
+		// Only initialize a new git repo if there is no parent git repo
+		// (i.e., if the closest .git is the projectDir itself, not a parent)
 		if !gitInfo.IsRepo {
 			projectGitFlow(ctx, provider, tmplContext, githubAction)
+		} else {
+			// Check if the found git repo is in a parent directory
+			// If so, do NOT run projectGitFlow (do not create a sub-repo)
+			// If the found .git is in projectDir, it's safe to run projectGitFlow
+			parentGitInfo, _ := deployer.GetGitInfo(logger, projectDir)
+			if parentGitInfo != nil && parentGitInfo.IsRepo {
+				// There is a .git in projectDir, so it's safe to run projectGitFlow
+				projectGitFlow(ctx, provider, tmplContext, githubAction)
+			} else {
+				// There is a parent git repo, do not create a sub-repo
+				logger.Info("Project is inside an existing git repository; not creating a new git repo.")
+			}
 		}
 
 		if format == "json" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project creation to prevent initializing a new git repository when the project is inside an existing git repository, avoiding nested git repos.
  * Added clearer informational messages when a project is created within an existing git repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->