### PR TITLE
Deployment: add new deployment options

### DIFF
--- a/agentuity.schema.json
+++ b/agentuity.schema.json
@@ -109,7 +109,7 @@
 						},
 						"idle": {
 							"type": "string",
-							"description": "The duration as a formatted string such as 1m, 10m, 1h, etc. This is only used if the mode is on-demand. If not provided, the default and the minimum idle period is 1m."
+							"description": "The duration as a formatted string such as 1m, 10m, 1h, etc. This is only used if the mode is on-demand. If not provided, the default and the minimum idle period is 10m."
 						}
 					}
 				},

--- a/agentuity.schema.json
+++ b/agentuity.schema.json
@@ -33,7 +33,11 @@
 		},
 		"development": {
 			"type": "object",
-			"required": ["port", "watch", "command"],
+			"required": [
+				"port",
+				"watch",
+				"command"
+			],
 			"properties": {
 				"port": {
 					"type": "integer",
@@ -41,7 +45,10 @@
 				},
 				"watch": {
 					"type": "object",
-					"required": ["enabled", "files"],
+					"required": [
+						"enabled",
+						"files"
+					],
 					"properties": {
 						"enabled": {
 							"type": "boolean",
@@ -71,7 +78,10 @@
 		},
 		"deployment": {
 			"type": "object",
-			"required": ["command", "resources"],
+			"required": [
+				"command",
+				"resources"
+			],
 			"properties": {
 				"command": {
 					"type": "string",
@@ -84,9 +94,39 @@
 					},
 					"description": "The arguments to pass to the command when running in the cloud deployment"
 				},
+				"mode": {
+					"type": "object",
+					"required": [
+						"type"
+					],
+					"properties": {
+						"type": {
+							"type": "string",
+							"enum": [
+								"on-demand",
+								"provisioned"
+							]
+						},
+						"idle": {
+							"type": "string",
+							"description": "The duration as a formatted string such as 1m, 10m, 1h, etc. This is only used if the mode is on-demand. If not provided, the default and the minimum idle period is 1m."
+						}
+					}
+				},
+				"dependencies": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"description": "The apt package dependencies to install before running the deployment"
+				},
 				"resources": {
 					"type": "object",
-					"required": ["memory", "cpu", "disk"],
+					"required": [
+						"memory",
+						"cpu",
+						"disk"
+					],
 					"properties": {
 						"memory": {
 							"type": "string",
@@ -109,7 +149,12 @@
 		},
 		"bundler": {
 			"type": "object",
-			"required": ["enabled", "identifier", "language", "agents"],
+			"required": [
+				"enabled",
+				"identifier",
+				"language",
+				"agents"
+			],
 			"properties": {
 				"enabled": {
 					"type": "boolean",
@@ -129,7 +174,9 @@
 				},
 				"agents": {
 					"type": "object",
-					"required": ["dir"],
+					"required": [
+						"dir"
+					],
 					"properties": {
 						"dir": {
 							"type": "string",
@@ -150,7 +197,10 @@
 			"type": "array",
 			"items": {
 				"type": "object",
-				"required": ["id", "name"],
+				"required": [
+					"id",
+					"name"
+				],
 				"properties": {
 					"id": {
 						"type": "string",

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -153,6 +153,9 @@ func initProject(ctx context.Context, logger logger.Logger, args InitProjectArgs
 	proj.Deployment.Resources.CPU = args.Provider.Deployment.Resources.CPU
 	proj.Deployment.Resources.Memory = args.Provider.Deployment.Resources.Memory
 	proj.Deployment.Resources.Disk = args.Provider.Deployment.Resources.Disk
+	proj.Deployment.Mode = &project.Mode{
+		Type: "on-demand",
+	}
 
 	// set the agents from the result
 	proj.Agents = result.Agents

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -117,10 +117,17 @@ type Resources struct {
 	DiskQuantity   resource.Quantity `json:"-" yaml:"-"`
 }
 
+type Mode struct {
+	Type string  `json:"type" yaml:"type" hc:"on-demand or provisioned"`                                       // on-demand or provisioned
+	Idle *string `json:"idle,omitempty" yaml:"idle,omitempty" hc:"duration in seconds if on-demand, optional"` // duration in seconds if on-demand, optional
+}
+
 type Deployment struct {
-	Command   string     `json:"command" yaml:"command"`
-	Args      []string   `json:"args" yaml:"args"`
-	Resources *Resources `json:"resources" yaml:"resources" hc:"You should tune the resources for the deployment"`
+	Command      string     `json:"command" yaml:"command"`
+	Args         []string   `json:"args" yaml:"args"`
+	Resources    *Resources `json:"resources" yaml:"resources" hc:"You should tune the resources for the deployment"`
+	Mode         *Mode      `json:"mode,omitempty" yaml:"mode,omitempty" hc:"The deployment mode"`
+	Dependencies []string   `json:"dependencies,omitempty" yaml:"dependencies,omitempty" hc:"The dependencies to install before running the deployment"`
 }
 
 type Watch struct {
@@ -216,6 +223,11 @@ func (p *Project) Load(dir string) error {
 				return fmt.Errorf("error validating deploy disk value '%s'. %w", p.Deployment.Resources.Disk, err)
 			}
 			p.Deployment.Resources.DiskQuantity = val
+		}
+		if p.Deployment.Mode != nil {
+			if p.Deployment.Mode.Type != "on-demand" && p.Deployment.Mode.Type != "provisioned" {
+				return fmt.Errorf("invalid deployment mode value: %s. only on-demand or provisioned are supported", p.Deployment.Mode.Type)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying deployment mode, allowing selection between "on-demand" and "provisioned" options, with an optional idle duration for on-demand mode.
  * Introduced the ability to list apt package dependencies to be installed before deployment.

* **Bug Fixes**
  * Improved validation to ensure only valid deployment mode types ("on-demand" or "provisioned") are accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->