### PR TITLE
Fix issue with deployment error not having a write to write out the error

### DIFF
--- a/internal/deployer/deployer.go
+++ b/internal/deployer/deployer.go
@@ -2,6 +2,7 @@ package deployer
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/agentuity/cli/internal/bundler"
@@ -75,6 +76,7 @@ func PreflightCheck(ctx context.Context, logger logger.Logger, data DeployPrefli
 		ProjectDir: data.Dir,
 		Production: true,
 		Project:    data.Project,
+		Writer:     os.Stderr,
 	}
 	if err := bundler.Bundle(bundleCtx); err != nil {
 		return nil, err


### PR DESCRIPTION
```
Caught panic:

runtime error: invalid memory address or nil pointer dereference

Restoring terminal...

goroutine 137 [running]:
runtime/debug.Stack()
        /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.4.linux-amd64/src/runtime/debug/stack.go:26 +0x5e
runtime/debug.PrintStack()
        /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.4.linux-amd64/src/runtime/debug/stack.go:18 +0x13
github.com/charmbracelet/bubbletea.(*Program).recoverFromPanic(0xc0001da3c0)
        /home/runner/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.4/tea.go:758 +0x8b
panic({0x1267ae0?, 0x1f730e0?})
        /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.4.linux-amd64/src/runtime/panic.go:792 +0x132
fmt.Fprintln({0x0, 0x0}, {0xc003a29620, 0x1, 0x1})
        /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.4.linux-amd64/src/fmt/print.go:305 +0x4e
github.com/agentuity/cli/internal/bundler.bundleJavascript({{0x164ed08, 0x1fde520}, {0x1657850, 0xc0001a6b40}, 0xc000281f10, {0xc000045ef0, 0x24}, 0x1, 0x0, 0x0, ...}, ...)
        /home/runner/_work/cli/cli/internal/bundler/bundler.go:291 +0x1cce
github.com/agentuity/cli/internal/bundler.Bundle({{0x164ed08, 0x1fde520}, {0x1657850, 0xc0001a6b40}, 0xc000281f10, {0xc000045ef0, 0x24}, 0x1, 0x0, 0x0, ...})
        /home/runner/_work/cli/cli/internal/bundler/bundler.go:447 +0x545
github.com/agentuity/cli/internal/deployer.PreflightCheck({0x5?, 0x0?}, {0x1657850, 0xc0001a6b40}, {{0xc000045ef0, 0x24}, 0xc0000fefa0, {0xc000121320, 0x19}, {0xc0003361c0, ...}, ...})
        /home/runner/_work/cli/cli/internal/deployer/deployer.go:79 +0xf8
github.com/agentuity/cli/cmd.init.func37.2()
        /home/runner/_work/cli/cli/cmd/cloud.go:286 +0x2f8
github.com/agentuity/go-common/tui.ShowSpinner.func1()
        /home/runner/go/pkg/mod/github.com/agentuity/go-common@v1.0.67/tui/spinner.go:31 +0x4e
github.com/agentuity/go-common/tui.ShowSpinner.(*Spinner).Action.func2({0xc0002e3730?, 0x2?})
        /home/runner/go/pkg/mod/github.com/charmbracelet/huh/spinner@v0.0.0-20250313000648-36d9de46d64e/spinner.go:74 +0x13
github.com/charmbracelet/huh/spinner.(*Spinner).Init.func1()
        /home/runner/go/pkg/mod/github.com/charmbracelet/huh/spinner@v0.0.0-20250313000648-36d9de46d64e/spinner.go:131 +0x31
github.com/charmbracelet/bubbletea.(*Program).handleCommands.func1.1()
        /home/runner/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.4/tea.go:352 +0x7d
created by github.com/charmbracelet/bubbletea.(*Program).handleCommands.func1 in goroutine 152
        /home/runner/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.4/tea.go:346 +0x131
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated output during the bundling process to be directed to the standard error stream for improved visibility of logs and messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->