### PR TITLE
Add curl cmd as mac fallback installation method

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -233,7 +233,12 @@ install_mac() {
     fi
 
   else
-      ohai "Installing Agentuity CLI using curl..."
+    ohai "Installing Agentuity CLI using curl..."
+    # Use the overridable CURL var, abort on error, and stop this script afterwards
+    if ! "$CURL" -fsSL https://agentuity.sh | sh; then
+      abort "cURL installation failed. Please check your connection or try --no-brew again."
+    fi
+    success      # print final message & exit 0
   fi
 
 }


### PR DESCRIPTION
It looks like we meant to call curl after this echo. Maybe I am missing something tho

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for macOS users installing without Homebrew, providing clearer messages and immediate termination if the installation fails.

* **Chores**
  * Enhanced the fallback installation process for better reliability and user feedback on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->