### PR TITLE
Fix issue with env on deploy asking for setting when set. Suppress some logs

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -244,7 +244,7 @@ Examples:
 
 			if !context.NewProject {
 				action = func() {
-					projectData, err = theproject.GetProject(ctx, logger, apiUrl, token, true, false)
+					projectData, err = theproject.GetProject(ctx, logger, apiUrl, token, false, false)
 					if err != nil {
 						if err == project.ErrProjectNotFound {
 							return
@@ -498,10 +498,23 @@ Examples:
 		zipaction := func() {
 			// zip up our directory
 			started := time.Now()
+			var seenGit, seenNodeModules bool
 			logger.Debug("creating a zip file of %s into %s", dir, tmpfile.Name())
 			if err := util.ZipDir(dir, tmpfile.Name(), util.WithMutator(zipMutator), util.WithMatcher(func(fn string, fi os.FileInfo) bool {
 				notok := rules.Ignore(fn, fi)
 				if notok {
+					if strings.HasPrefix(fn, ".git") {
+						if seenGit {
+							return false
+						}
+						seenGit = true
+					}
+					if strings.HasPrefix(fn, "node_modules") {
+						if seenNodeModules {
+							return false
+						}
+						seenNodeModules = true
+					}
 					logger.Trace("❌ %s", fn)
 				} else {
 					logger.Trace("❎ %s", fn)

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -498,7 +498,7 @@ Examples:
 		zipaction := func() {
 			// zip up our directory
 			started := time.Now()
-			var seenGit, seenNodeModules bool
+			var seenGit, seenNodeModules, sendVenv bool
 			logger.Debug("creating a zip file of %s into %s", dir, tmpfile.Name())
 			if err := util.ZipDir(dir, tmpfile.Name(), util.WithMutator(zipMutator), util.WithMatcher(func(fn string, fi os.FileInfo) bool {
 				notok := rules.Ignore(fn, fi)
@@ -514,6 +514,12 @@ Examples:
 							return false
 						}
 						seenNodeModules = true
+					}
+					if strings.HasPrefix(fn, ".venv") {
+						if sendVenv {
+							return false
+						}
+						sendVenv = true
 					}
 					logger.Trace("❌ %s", fn)
 				} else {

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -498,7 +498,7 @@ Examples:
 		zipaction := func() {
 			// zip up our directory
 			started := time.Now()
-			var seenGit, seenNodeModules, sendVenv bool
+			var seenGit, seenNodeModules, seenVenv bool
 			logger.Debug("creating a zip file of %s into %s", dir, tmpfile.Name())
 			if err := util.ZipDir(dir, tmpfile.Name(), util.WithMutator(zipMutator), util.WithMatcher(func(fn string, fi os.FileInfo) bool {
 				notok := rules.Ignore(fn, fi)
@@ -516,10 +516,10 @@ Examples:
 						seenNodeModules = true
 					}
 					if strings.HasPrefix(fn, ".venv") {
-						if sendVenv {
+						if seenVenv {
 							return false
 						}
-						sendVenv = true
+						seenVenv = true
 					}
 					logger.Trace("❌ %s", fn)
 				} else {


### PR DESCRIPTION
@potofpie this fixes that issue with the secret we saw and the annoying long node_modules on debug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment packaging to prevent multiple inclusions of `.git`, `node_modules`, and `.venv` directories in the deployment package.

* **Other Improvements**
  * Adjusted project data retrieval behavior during deployment for better efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->