### PR TITLE
Added —dry-run command

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -540,6 +540,14 @@ Examples:
 
 		if dryRun != "" {
 
+			// Validate and create the dryRun directory if it doesn't exist
+			if !util.Exists(dryRun) {
+				if err := os.MkdirAll(dryRun, 0755); err != nil {
+					errsystem.New(errsystem.ErrCreateZipFile, err,
+						errsystem.WithContextMessage(fmt.Sprintf("Error creating dry run directory '%s': %v", dryRun, err))).ShowErrorAndExit()
+				}
+			}
+
 			outputFile := filepath.Join(dryRun, fmt.Sprintf("agentuity-deploy-%s.zip", theproject.ProjectId))
 
 			if _, err := util.CopyFile(tmpfile.Name(), outputFile); err != nil {

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -538,18 +538,10 @@ Examples:
 
 		tui.ShowSpinner("Packaging ...", zipaction)
 
-		// Handle dry-run case - check if flag was specified
-		dryRunSpecified := cmd.Flags().Changed("dry-run")
-		if dryRunSpecified {
-			// Default to current directory if empty string
-			if dryRun == "" {
-				dryRun = "."
-			}
+		if dryRun != "" {
 
-			// Create the output filename
 			outputFile := filepath.Join(dryRun, fmt.Sprintf("agentuity-deploy-%s.zip", theproject.ProjectId))
 
-			// Copy the zip file to the specified location
 			if _, err := util.CopyFile(tmpfile.Name(), outputFile); err != nil {
 				errsystem.New(errsystem.ErrCreateZipFile, err,
 					errsystem.WithContextMessage("Error copying deployment zip file")).ShowErrorAndExit()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a `--dry-run` option for the deployment command, allowing users to save the deployment package locally without uploading or deploying.
  * Provides clear output indicating the location and details of the saved package when using the dry-run option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->