### PR TITLE
Allow setup.sh in case we need to run some script in docker image

### DIFF
--- a/internal/ignore/rules_test.go
+++ b/internal/ignore/rules_test.go
@@ -36,12 +36,14 @@ func TestRules(t *testing.T) {
 	assert.True(t, rules.Ignore("/Users/foobar/example/.foo.swp", nil))
 	assert.True(t, rules.Ignore("/Users/foobar/example/src/__test__/test_bar.py", nil))
 	assert.True(t, rules.Ignore("/Users/foobar/example/.agentuity-12345", nil))
+	assert.False(t, rules.Ignore("/Users/foobar/setup.sh", nil))
 }
 
 func TestNegateRules(t *testing.T) {
 	rules := Empty()
 	rules.AddDefaults()
-	rules.Add("!**/foo.py")
+	rules.Add("**/*.py")    // First ignore all Python files
+	rules.Add("!**/foo.py") // Then negate foo.py specifically
 	assert.False(t, rules.Ignore("/Users/foobar/example/src/foo.py", nil))
 	assert.False(t, rules.Ignore("foo.py", nil))
 	assert.True(t, rules.Ignore("bar.py", nil))


### PR DESCRIPTION
The `setup.sh` file is a valid setup file, currently being ignored by the bundler. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that the file named "setup.sh" will no longer be ignored by the ignore rules.
  * Improved handling of negation patterns to correctly override ignore rules for specific files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->