### PR TITLE
Exclude the .jj folder automatically

### DIFF
--- a/internal/ignore/rules.go
+++ b/internal/ignore/rules.go
@@ -65,6 +65,8 @@ func (r *Rules) AddDefaults() {
 	r.parseRule("**/.venv/**/*")
 	r.parseRule("**/.git/**/*")
 	r.parseRule("**/.git")
+	r.parseRule("**/.jj/**/*")
+	r.parseRule("**/.jj")
 	r.parseRule("**/__pycache__/**")
 	r.parseRule("**/__tests__/**")
 	r.parseRule("**/*.zip")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added default ignore support for .jj directories and their contents. These folders will no longer appear in listings or operations that respect ignore rules.
- Chores
  - Updated default ignore configuration to include .jj alongside existing ignores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->