### PR TITLE
[AGENT-628] prevent local development env files from syncing to production

### DIFF
--- a/internal/envutil/envutil.go
+++ b/internal/envutil/envutil.go
@@ -66,7 +66,11 @@ func ProcessEnvFiles(ctx context.Context, logger logger.Logger, dir string, thep
 				errsystem.WithContextMessage("Error parsing .env file")).ShowErrorAndExit()
 		}
 
-		projectData = HandleMissingProjectEnvs(ctx, logger, le, projectData, theproject, apiUrl, token, force)
+		// Only sync env vars to production when not in local development mode
+		// Local development files (.env.development, .env.local, etc.) should never be synced to production
+		if !isLocalDev {
+			projectData = HandleMissingProjectEnvs(ctx, logger, le, projectData, theproject, apiUrl, token, force)
+		}
 		envFile.Env = le
 		return envFile, projectData
 	}

--- a/internal/envutil/envutil.go
+++ b/internal/envutil/envutil.go
@@ -69,7 +69,7 @@ func ProcessEnvFiles(ctx context.Context, logger logger.Logger, dir string, thep
 		// Only sync env vars to production when not in local development mode
 		// Local development files (.env.development, .env.local, etc.) should never be synced to production
 		if !isLocalDev {
-			projectData = HandleMissingProjectEnvs(ctx, logger, le, projectData, theproject, apiUrl, token, force)
+			projectData = HandleMissingProjectEnvs(ctx, logger, le, projectData, theproject, apiUrl, token, force, envfilename)
 		}
 		envFile.Env = le
 		return envFile, projectData
@@ -153,7 +153,7 @@ func HandleMissingTemplateEnvs(logger logger.Logger, dir, envfilename string, le
 }
 
 // HandleMissingProjectEnvs handles missing envs in project
-func HandleMissingProjectEnvs(ctx context.Context, logger logger.Logger, le []env.EnvLineComment, projectData *project.ProjectData, theproject *project.Project, apiUrl, token string, force bool) *project.ProjectData {
+func HandleMissingProjectEnvs(ctx context.Context, logger logger.Logger, le []env.EnvLineComment, projectData *project.ProjectData, theproject *project.Project, apiUrl, token string, force bool, envFilename string) *project.ProjectData {
 
 	if projectData == nil {
 		projectData = &project.ProjectData{}
@@ -175,14 +175,18 @@ func HandleMissingProjectEnvs(ctx context.Context, logger logger.Logger, le []en
 		if !force {
 			var title string
 			var suffix string
+			var question string
+			envFileDisplayName := tui.Bold(filepath.Base(envFilename))
+
 			switch {
 			case len(keyvalue) < 3 && len(keyvalue) > 1:
-				suffix = "it"
+				suffix = "them"
 				var colorized []string
 				for key := range keyvalue {
 					colorized = append(colorized, tui.Bold(key))
 				}
-				title = fmt.Sprintf("The environment variables %s from %s are not been set in the project.", strings.Join(colorized, ", "), tui.Bold(".env"))
+				title = fmt.Sprintf("The environment variables %s from %s are not set in your cloud project.", strings.Join(colorized, ", "), envFileDisplayName)
+				question = fmt.Sprintf("Would you like to sync %s to your cloud project now?", suffix)
 			case len(keyvalue) == 1:
 				var key string
 				for _key := range keyvalue {
@@ -190,13 +194,16 @@ func HandleMissingProjectEnvs(ctx context.Context, logger logger.Logger, le []en
 					break
 				}
 				suffix = "it"
-				title = fmt.Sprintf("The environment variable %s from %s has not been set in the project.", tui.Bold(key), tui.Bold(".env"))
+				title = fmt.Sprintf("The environment variable %s from %s has not been set in your cloud project.", tui.Bold(key), envFileDisplayName)
+				question = fmt.Sprintf("Would you like to sync %s to your cloud project now?", suffix)
 			default:
 				suffix = "them"
-				title = fmt.Sprintf("There are %d environment variables from %s that are not set in the project.", len(keyvalue), tui.Bold(".env"))
+				title = fmt.Sprintf("There are %d environment variables from %s that are not set in your cloud project.", len(keyvalue), envFileDisplayName)
+				question = fmt.Sprintf("Would you like to sync %s to your cloud project now?", suffix)
 			}
 			fmt.Println(title)
-			force = tui.Ask(logger, "Would you like to set "+suffix+" now?", true)
+			fmt.Println(tui.Muted("(Choosing 'no' won't affect your local development - these variables will still work locally)"))
+			force = tui.Ask(logger, question, true)
 		}
 		if force {
 			for key, val := range keyvalue {


### PR DESCRIPTION
Local development files (.env.development, .env.local, etc.) should never be synced to the production database. This was causing the CLI to prompt users to sync development-only environment variables to their cloud project.

The fix adds a conditional check to only call HandleMissingProjectEnvs when not in local development mode (isLocalDev = false).

Fixes issue where users were getting prompted to sync env vars from .env.development files to production.


Amp-Thread-ID: https://ampcode.com/threads/T-94a6a673-ef07-4dbd-95a8-8437d17bdd21


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents syncing missing project environment variables to production when running in local development, reducing risk of unintended production changes.
* **New Features**
  * Improved user prompts: environment file names are shown, messages correctly pluralize variables, and a muted note clarifies opting out won’t affect local development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->