### PR TITLE
Fix npm workspaces

### DIFF
--- a/internal/bundler/bundler_test.go
+++ b/internal/bundler/bundler_test.go
@@ -38,16 +38,16 @@ func TestPyProject(t *testing.T) {
 }
 
 // Helper function to test package manager detection logic
-func testPackageManagerCommand(t *testing.T, tempDir string, runtime string, isCI bool, expectedCmd string, expectedArgs []string) {
+func testPackageManagerCommand(t *testing.T, tempDir string, runtime string, isCI bool, isWorkspace bool, expectedCmd string, expectedArgs []string) {
 	ctx := BundleContext{
 		Context: context.Background(),
 		Logger:  nil, // nil logger will skip bun lockfile generation in tests
 		CI:      isCI,
 	}
-	
-	actualCmd, actualArgs, err := getJSInstallCommand(ctx, tempDir, runtime)
+
+	actualCmd, actualArgs, err := getJSInstallCommand(ctx, tempDir, runtime, isWorkspace)
 	require.NoError(t, err)
-	
+
 	assert.Equal(t, expectedCmd, actualCmd)
 	assert.Equal(t, expectedArgs, actualArgs)
 }
@@ -130,7 +130,7 @@ func TestJavaScriptPackageManagerDetection(t *testing.T) {
 			}
 
 			// Test the logic with CI=false
-			testPackageManagerCommand(t, tempDir, tt.runtime, false, tt.expectedCmd, tt.expectedArgs)
+			testPackageManagerCommand(t, tempDir, tt.runtime, false, false, tt.expectedCmd, tt.expectedArgs)
 		})
 	}
 }
@@ -144,6 +144,7 @@ func TestPnpmCIFlags(t *testing.T) {
 		tempDir,
 		"pnpm",
 		true,
+		false, // isWorkspace=false
 		"pnpm",
 		[]string{"install", "--prod", "--ignore-scripts", "--reporter=append-only", "--frozen-lockfile"},
 	)
@@ -153,7 +154,86 @@ func TestPnpmCIFlags(t *testing.T) {
 		tempDir,
 		"pnpm",
 		false,
+		false, // isWorkspace=false
 		"pnpm",
 		[]string{"install", "--prod", "--ignore-scripts", "--silent"},
 	)
+}
+
+func TestMatchesWorkspacePattern(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		pattern  string
+		expected bool
+	}{
+		// Basic exact match
+		{"exact match", "packages/core", "packages/core", true},
+		{"no match", "packages/core", "packages/utils", false},
+
+		// Simple glob patterns
+		{"single star", "packages/core", "packages/*", true},
+		{"single star no match", "packages/core/src", "packages/*", false},
+
+		// Double star patterns (recursive)
+		{"double star recursive", "packages/core/src/index.ts", "packages/**/index.ts", true},
+		{"double star deep", "src/components/ui/button/index.ts", "**/button/index.ts", true},
+		{"double star no match", "packages/core/src/main.ts", "packages/**/index.ts", false},
+
+		// Negation patterns
+		{"negation match", "packages/excluded", "!packages/excluded", false},
+		{"negation no match", "packages/included", "!packages/excluded", true},
+
+		// Cross-platform path handling (normalize different separator styles)
+		{"windows-style path", filepath.Join("packages", "core"), "packages/*", true},
+		{"nested path", filepath.Join("packages", "core", "src"), "packages/**/src", true},
+
+		// Complex patterns
+		{"file extension", "src/test.spec.ts", "**/*.spec.ts", true},
+		{"multiple levels", "apps/web/src/pages/index.tsx", "apps/*/src/**/*.tsx", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := matchesWorkspacePattern(tt.path, tt.pattern)
+			assert.Equal(t, tt.expected, result, "pattern %q should match path %q: %v", tt.pattern, tt.path, tt.expected)
+		})
+	}
+}
+
+func TestNpmStyleGlobPatterns(t *testing.T) {
+	// Test specific patterns mentioned in the original issue
+	tests := []struct {
+		name     string
+		path     string
+		pattern  string
+		expected bool
+	}{
+		// Test "packages/**/src" pattern with deep nesting
+		{"deep nested src", "packages/ui/components/src", "packages/**/src", true},
+		{"deep nested src file", "packages/ui/components/src/index.ts", "packages/**/src/*", true},
+
+		// Test "**/*" pattern for matching everything
+		{"match all files", "any/deeply/nested/file.ts", "**/*", true},
+		{"match all directories", "any/deeply/nested/dir", "**/*", true},
+
+		// Test negation patterns like "!excluded"
+		{"exclude specific pattern", "packages/excluded", "!packages/excluded", false},
+		{"include non-excluded", "packages/included", "!packages/excluded", true},
+		{"exclude with wildcards", "test/excluded/file.ts", "!test/excluded/**", false},
+		{"include with wildcards", "test/included/file.ts", "!test/excluded/**", true},
+
+		// Test exact patterns that the old implementation might have broken
+		{"exact directory match", "packages", "packages", true},
+		{"exact file match", "package.json", "package.json", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := matchesWorkspacePattern(tt.path, tt.pattern)
+			assert.Equal(t, tt.expected, result,
+				"pattern %q should match path %q: expected %v, got %v",
+				tt.pattern, tt.path, tt.expected, result)
+		})
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic detection of npm, Yarn, pnpm, and Bun workspaces with workspace-aware installs.
  * Installs dependencies at the correct workspace root in monorepos.
  * Smarter command selection across package managers in both local and CI environments.
* **Bug Fixes**
  * More reliable installs in monorepos by avoiding hardcoded paths.
  * Null-safe handling when no workspace is present.
* **Tests**
  * Added comprehensive tests for workspace glob pattern matching.
  * Updated tests to cover workspace-aware command generation and CI scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->