### PR TITLE
Add support for importing: yaml, json, txt, png, gif, jpg, svg, webp, md, csv, pdf, sql, xml

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -280,6 +280,10 @@ func bundleJavascript(ctx BundleContext, dir string, outdir string, theproject *
 		return err
 	}
 
+	if err := possiblyCreateDeclarationFile(ctx.Logger, dir); err != nil {
+		return err
+	}
+
 	if err := runTypecheck(ctx, dir); err != nil {
 		return err
 	}
@@ -334,6 +338,7 @@ func bundleJavascript(ctx BundleContext, dir string, outdir string, theproject *
 
 	ctx.Logger.Debug("starting build")
 	started := time.Now()
+
 	result := api.Build(api.BuildOptions{
 		EntryPoints:    entryPoints,
 		Bundle:         true,
@@ -347,11 +352,17 @@ func bundleJavascript(ctx BundleContext, dir string, outdir string, theproject *
 		Engines: []api.Engine{
 			{Name: api.EngineNode, Version: "22"},
 		},
-		External:      []string{"bun"},
+		External:      []string{"bun", "fsevents"},
 		AbsWorkingDir: dir,
 		TreeShaking:   api.TreeShakingTrue,
 		Drop:          api.DropDebugger,
-		Plugins:       []api.Plugin{createPlugin(ctx.Logger, dir, shimSourceMap)},
+		Plugins: []api.Plugin{
+			createPlugin(ctx.Logger, dir, shimSourceMap),
+			createYAMLImporter(ctx.Logger),
+			createJSONImporter(ctx.Logger),
+			createTextImporter(ctx.Logger),
+			createFileImporter(ctx.Logger),
+		},
 		Define:        defines,
 		LegalComments: api.LegalCommentsNone,
 		Banner: map[string]string{

--- a/internal/bundler/bundler_test.go
+++ b/internal/bundler/bundler_test.go
@@ -44,10 +44,10 @@ func testPackageManagerCommand(t *testing.T, tempDir string, runtime string, isC
 		Logger:  nil, // nil logger will skip bun lockfile generation in tests
 		CI:      isCI,
 	}
-	
+
 	actualCmd, actualArgs, err := getJSInstallCommand(ctx, tempDir, runtime)
 	require.NoError(t, err)
-	
+
 	assert.Equal(t, expectedCmd, actualCmd)
 	assert.Equal(t, expectedArgs, actualArgs)
 }

--- a/internal/bundler/importers.go
+++ b/internal/bundler/importers.go
@@ -130,7 +130,7 @@ func createTextImporter(logger logger.Logger) api.Plugin {
 	return api.Plugin{
 		Name: "text",
 		Setup: func(build api.PluginBuild) {
-			filter := "\\.(txt)$"
+			filter := "\\.(txt|md|csv|xml|sql)$"
 			build.OnResolve(api.OnResolveOptions{Filter: filter, Namespace: "file"}, func(args api.OnResolveArgs) (api.OnResolveResult, error) {
 				p := makePath(args)
 				if isNodeModulesPath(p) {
@@ -222,6 +222,26 @@ declare module '*.webp' {
 }
 
 declare module '*.txt' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.md' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.csv' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.xml' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.sql' {
   const value: string;
   export default value;
 }

--- a/internal/bundler/importers.go
+++ b/internal/bundler/importers.go
@@ -41,12 +41,12 @@ func createYAMLImporter(logger logger.Logger) api.Plugin {
 					return api.OnLoadResult{}, err
 				}
 				defer of.Close()
-				kv := make(map[string]any)
+				var kv any
 				err = yaml.NewDecoder(of).Decode(&kv)
 				if err != nil {
 					return api.OnLoadResult{}, err
 				}
-				js := "module.exports = " + cstr.JSONStringify(kv)
+				js := "export default " + cstr.JSONStringify(kv)
 				logger.Debug("bundling yaml file from %s", args.Path)
 				return api.OnLoadResult{Contents: &js, Loader: api.LoaderJS}, nil
 			})
@@ -82,12 +82,12 @@ func createJSONImporter(logger logger.Logger) api.Plugin {
 					return api.OnLoadResult{}, err
 				}
 				defer of.Close()
-				kv := make(map[string]any)
+				var kv any
 				err = json.NewDecoder(of).Decode(&kv)
 				if err != nil {
 					return api.OnLoadResult{}, err
 				}
-				js := "module.exports = " + cstr.JSONStringify(kv)
+				js := "export default " + cstr.JSONStringify(kv)
 				logger.Debug("bundling json file from %s", args.Path)
 				return api.OnLoadResult{Contents: &js, Loader: api.LoaderJS}, nil
 			})
@@ -123,7 +123,7 @@ func createFileImporter(logger logger.Logger) api.Plugin {
 					return api.OnLoadResult{}, err
 				}
 				base64Data := base64.StdEncoding.EncodeToString(data)
-				js := "module.exports = Buffer.from('" + base64Data + "', 'base64');"
+				js := "export default Buffer.from(" + cstr.JSONStringify(base64Data) + ", 'base64');"
 				logger.Debug("bundling binary file from %s", args.Path)
 				return api.OnLoadResult{Contents: &js, Loader: api.LoaderJS}, nil
 			})
@@ -138,7 +138,7 @@ func createTextImporter(logger logger.Logger) api.Plugin {
 		Name: "text",
 		Setup: func(build api.PluginBuild) {
 			filter := "\\.(txt)$"
-			build.OnResolve(api.OnResolveOptions{Filter: filter, Namespace: "text"}, func(args api.OnResolveArgs) (api.OnResolveResult, error) {
+			build.OnResolve(api.OnResolveOptions{Filter: filter, Namespace: "file"}, func(args api.OnResolveArgs) (api.OnResolveResult, error) {
 				p := args.Path
 				abs, err := filepath.Abs(p)
 				if err != nil {
@@ -158,7 +158,7 @@ func createTextImporter(logger logger.Logger) api.Plugin {
 				if err != nil {
 					return api.OnLoadResult{}, err
 				}
-				js := "module.exports = " + cstr.JSONStringify(data)
+				js := "export default " + cstr.JSONStringify(string(data))
 				logger.Debug("bundling text file from %s", args.Path)
 				return api.OnLoadResult{Contents: &js, Loader: api.LoaderJS}, nil
 			})
@@ -206,37 +206,37 @@ declare module '*.json' {
 }
 
 declare module '*.png' {
-  const value: any;
+  const value: Buffer;
   export default value;
 }
 
 declare module '*.gif' {
-  const value: any;
+  const value: Buffer;
   export default value;
 }
 
 declare module '*.jpg' {
-  const value: any;
+  const value: Buffer;
   export default value;
 }
 
 declare module '*.jpeg' {
-  const value: any;
+  const value: Buffer;
   export default value;
 }
 
 declare module '*.svg' {
-  const value: any;
+  const value: Buffer;
   export default value;
 }
 
 declare module '*.webp' {
-  const value: any;
+  const value: Buffer;
   export default value;
 }
 
 declare module '*.txt' {
-  const value: any;
+  const value: string;
   export default value;
 }
 `

--- a/internal/bundler/importers.go
+++ b/internal/bundler/importers.go
@@ -15,20 +15,23 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func makePath(args api.OnResolveArgs) string {
+	p := args.Path
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(args.ResolveDir, p)
+	} else {
+		p = filepath.Clean(p)
+	}
+	return p
+}
+
 func createYAMLImporter(logger logger.Logger) api.Plugin {
 	return api.Plugin{
 		Name: "yaml",
 		Setup: func(build api.PluginBuild) {
 			filter := "\\.ya?ml$"
 			build.OnResolve(api.OnResolveOptions{Filter: filter, Namespace: "file"}, func(args api.OnResolveArgs) (api.OnResolveResult, error) {
-				p := args.Path
-				abs, err := filepath.Abs(p)
-				if err != nil {
-					return api.OnResolveResult{}, err
-				}
-				if abs != p {
-					p = filepath.Join(args.ResolveDir, p)
-				}
+				p := makePath(args)
 				if strings.Contains(p, "node_modules/") {
 					return api.OnResolveResult{}, nil
 				}
@@ -62,14 +65,7 @@ func createJSONImporter(logger logger.Logger) api.Plugin {
 		Setup: func(build api.PluginBuild) {
 			filter := "\\.json$"
 			build.OnResolve(api.OnResolveOptions{Filter: filter, Namespace: "file"}, func(args api.OnResolveArgs) (api.OnResolveResult, error) {
-				p := args.Path
-				abs, err := filepath.Abs(p)
-				if err != nil {
-					return api.OnResolveResult{}, err
-				}
-				if abs != p {
-					p = filepath.Join(args.ResolveDir, p)
-				}
+				p := makePath(args)
 				if strings.Contains(p, "node_modules/") {
 					return api.OnResolveResult{}, nil
 				}
@@ -103,14 +99,7 @@ func createFileImporter(logger logger.Logger) api.Plugin {
 		Setup: func(build api.PluginBuild) {
 			filter := "\\.(gif|png|jpg|jpeg|svg|webp)$"
 			build.OnResolve(api.OnResolveOptions{Filter: filter, Namespace: "file"}, func(args api.OnResolveArgs) (api.OnResolveResult, error) {
-				p := args.Path
-				abs, err := filepath.Abs(p)
-				if err != nil {
-					return api.OnResolveResult{}, err
-				}
-				if abs != p {
-					p = filepath.Join(args.ResolveDir, p)
-				}
+				p := makePath(args)
 				if strings.Contains(p, "node_modules/") {
 					return api.OnResolveResult{}, nil
 				}
@@ -139,14 +128,7 @@ func createTextImporter(logger logger.Logger) api.Plugin {
 		Setup: func(build api.PluginBuild) {
 			filter := "\\.(txt)$"
 			build.OnResolve(api.OnResolveOptions{Filter: filter, Namespace: "file"}, func(args api.OnResolveArgs) (api.OnResolveResult, error) {
-				p := args.Path
-				abs, err := filepath.Abs(p)
-				if err != nil {
-					return api.OnResolveResult{}, err
-				}
-				if abs != p {
-					p = filepath.Join(args.ResolveDir, p)
-				}
+				p := makePath(args)
 				if strings.Contains(p, "node_modules/") {
 					return api.OnResolveResult{}, nil
 				}

--- a/internal/bundler/importers.go
+++ b/internal/bundler/importers.go
@@ -101,7 +101,7 @@ func createFileImporter(logger logger.Logger) api.Plugin {
 	return api.Plugin{
 		Name: "file",
 		Setup: func(build api.PluginBuild) {
-			filter := "\\.(gif|png|jpg|jpeg|svg|webp)$"
+			filter := "\\.(gif|png|jpg|jpeg|svg|webp|pdf)$"
 			build.OnResolve(api.OnResolveOptions{Filter: filter, Namespace: "file"}, func(args api.OnResolveArgs) (api.OnResolveResult, error) {
 				p := makePath(args)
 				if isNodeModulesPath(p) {
@@ -217,6 +217,11 @@ declare module '*.svg' {
 }
 
 declare module '*.webp' {
+  const value: Buffer;
+  export default value;
+}
+
+declare module '*.pdf' {
   const value: Buffer;
   export default value;
 }

--- a/internal/bundler/importers.go
+++ b/internal/bundler/importers.go
@@ -177,7 +177,7 @@ func possiblyCreateDeclarationFile(logger logger.Logger, dir string) error {
 		return fmt.Errorf("cannot create file: %s. %w", fn, err)
 	}
 	logger.Debug("created declaration file at %s", mfp)
-	err = os.WriteFile(fn, []byte(mfp), 0644)
+	err = os.WriteFile(mfp, []byte(declaration), 0644)
 	if err != nil {
 		return fmt.Errorf("cannot create file: %s. %w", fn, err)
 	}

--- a/internal/bundler/importers.go
+++ b/internal/bundler/importers.go
@@ -116,7 +116,7 @@ func createFileImporter(logger logger.Logger) api.Plugin {
 					return api.OnLoadResult{}, err
 				}
 				base64Data := base64.StdEncoding.EncodeToString(data)
-				js := "export default Buffer.from(" + cstr.JSONStringify(base64Data) + ", 'base64');"
+				js := "export default new Uint8Array(atob(" + cstr.JSONStringify(base64Data) + ").split('').map(c => c.charCodeAt(0)));"
 				logger.Debug("bundling binary file from %s", args.Path)
 				return api.OnLoadResult{Contents: &js, Loader: api.LoaderJS}, nil
 			})
@@ -192,37 +192,37 @@ declare module '*.json' {
 }
 
 declare module '*.png' {
-  const value: Buffer;
+  const value: Uint8Array;
   export default value;
 }
 
 declare module '*.gif' {
-  const value: Buffer;
+  const value: Uint8Array;
   export default value;
 }
 
 declare module '*.jpg' {
-  const value: Buffer;
+  const value: Uint8Array;
   export default value;
 }
 
 declare module '*.jpeg' {
-  const value: Buffer;
+  const value: Uint8Array;
   export default value;
 }
 
 declare module '*.svg' {
-  const value: Buffer;
+  const value: Uint8Array;
   export default value;
 }
 
 declare module '*.webp' {
-  const value: Buffer;
+  const value: Uint8Array;
   export default value;
 }
 
 declare module '*.pdf' {
-  const value: Buffer;
+  const value: Uint8Array;
   export default value;
 }
 

--- a/internal/bundler/importers.go
+++ b/internal/bundler/importers.go
@@ -116,7 +116,7 @@ func createFileImporter(logger logger.Logger) api.Plugin {
 					return api.OnLoadResult{}, err
 				}
 				base64Data := base64.StdEncoding.EncodeToString(data)
-				js := "export default new Uint8Array(atob(" + cstr.JSONStringify(base64Data) + ").split('').map(c => c.charCodeAt(0)));"
+				js := "export default new Uint8Array(Buffer.from(" + cstr.JSONStringify(base64Data) + ", \"base64\"));"
 				logger.Debug("bundling binary file from %s", args.Path)
 				return api.OnLoadResult{Contents: &js, Loader: api.LoaderJS}, nil
 			})

--- a/internal/bundler/importers.go
+++ b/internal/bundler/importers.go
@@ -155,6 +155,11 @@ func createTextImporter(logger logger.Logger) api.Plugin {
 }
 
 func possiblyCreateDeclarationFile(logger logger.Logger, dir string) error {
+	mfp := filepath.Join(dir, "node_modules", "@agentuity", "sdk", "dist", "file_types.d.ts")
+	if sys.Exists(mfp) {
+		logger.Debug("found existing declaration file at %s", mfp)
+		return nil
+	}
 	fp := filepath.Join(dir, "node_modules", "@types", "agentuity")
 	fn := filepath.Join(fp, "index.d.ts")
 	if sys.Exists(fn) {
@@ -168,6 +173,11 @@ func possiblyCreateDeclarationFile(logger logger.Logger, dir string) error {
 		logger.Debug("created directory %s", fp)
 	}
 	err := os.WriteFile(fn, []byte(declaration), 0644)
+	if err != nil {
+		return fmt.Errorf("cannot create file: %s. %w", fn, err)
+	}
+	logger.Debug("created declaration file at %s", mfp)
+	err = os.WriteFile(fn, []byte(mfp), 0644)
 	if err != nil {
 		return fmt.Errorf("cannot create file: %s. %w", fn, err)
 	}

--- a/internal/bundler/importers_test.go
+++ b/internal/bundler/importers_test.go
@@ -1,0 +1,242 @@
+package bundler
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agentuity/go-common/logger"
+)
+
+// Mock logger for testing
+type mockLogger struct{}
+
+func (m *mockLogger) Trace(format string, args ...interface{}) {}
+func (m *mockLogger) Debug(format string, args ...interface{}) {}
+func (m *mockLogger) Info(format string, args ...interface{})  {}
+func (m *mockLogger) Warn(format string, args ...interface{})  {}
+func (m *mockLogger) Error(format string, args ...interface{}) {}
+func (m *mockLogger) Fatal(format string, args ...interface{}) {}
+func (m *mockLogger) IsTraceEnabled() bool                     { return false }
+func (m *mockLogger) IsDebugEnabled() bool                     { return false }
+func (m *mockLogger) IsInfoEnabled() bool                      { return false }
+func (m *mockLogger) IsWarnEnabled() bool                      { return false }
+func (m *mockLogger) IsErrorEnabled() bool                     { return false }
+func (m *mockLogger) IsFatalEnabled() bool                     { return false }
+func (m *mockLogger) WithField(key string, value interface{}) logger.Logger { return m }
+func (m *mockLogger) WithFields(fields map[string]interface{}) logger.Logger { return m }
+func (m *mockLogger) WithError(err error) logger.Logger                      { return m }
+func (m *mockLogger) Stack(logger logger.Logger) logger.Logger               { return m }
+func (m *mockLogger) With(fields map[string]interface{}) logger.Logger       { return m }
+func (m *mockLogger) WithContext(ctx context.Context) logger.Logger          { return m }
+func (m *mockLogger) WithPrefix(prefix string) logger.Logger                 { return m }
+
+func TestImportInsertion(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputContent   string
+		expectedOutput string
+		shouldInsert   bool
+	}{
+		{
+			name: "insert after export with relative import",
+			inputContent: `export { Tool } from './tool';
+export { Agent } from './agent';
+declare module '@agentuity/sdk' {
+  export interface Config {}
+}`,
+			expectedOutput: `export { Tool } from './tool';
+import './file_types';
+export { Agent } from './agent';
+declare module '@agentuity/sdk' {
+  export interface Config {}
+}`,
+			shouldInsert: true,
+		},
+		{
+			name: "insert after last export when no relative imports",
+			inputContent: `export interface Tool {}
+export class Agent {}
+declare module '@agentuity/sdk' {
+  export interface Config {}
+}`,
+			expectedOutput: `export interface Tool {}
+export class Agent {}
+import './file_types';
+declare module '@agentuity/sdk' {
+  export interface Config {}
+}`,
+			shouldInsert: true,
+		},
+		{
+			name: "don't insert when import already exists with single quotes",
+			inputContent: `export { Tool } from './tool';
+import './file_types';
+export { Agent } from './agent';`,
+			expectedOutput: `export { Tool } from './tool';
+import './file_types';
+export { Agent } from './agent';`,
+			shouldInsert: false,
+		},
+		{
+			name: "don't insert when import already exists with double quotes",
+			inputContent: `export { Tool } from "./tool";
+import "./file_types";
+export { Agent } from "./agent";`,
+			expectedOutput: `export { Tool } from "./tool";
+import "./file_types";
+export { Agent } from "./agent";`,
+			shouldInsert: false,
+		},
+		{
+			name: "append at end when only exports exist",
+			inputContent: `export interface Tool {}
+export class Agent {}`,
+			expectedOutput: `export interface Tool {}
+export class Agent {}
+import './file_types';`,
+			shouldInsert: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary directory and files
+			tmpDir, err := os.MkdirTemp("", "bundler_test")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			// Create SDK directory structure
+			sdkDir := filepath.Join(tmpDir, "node_modules", "@agentuity", "sdk", "dist")
+			err = os.MkdirAll(sdkDir, 0755)
+			if err != nil {
+				t.Fatalf("failed to create SDK dir: %v", err)
+			}
+
+			// Write test content to index.d.ts  
+			indexPath := filepath.Join(sdkDir, "index.d.ts")
+			err = os.WriteFile(indexPath, []byte(tt.inputContent), 0644)
+			if err != nil {
+				t.Fatalf("failed to write test file: %v", err)
+			}
+			
+
+			
+			// Also need to create the file_types.d.ts file that the patching logic expects to exist
+			// This triggers the SDK patching logic
+			fileTypesPath := filepath.Join(sdkDir, "file_types.d.ts") 
+			err = os.WriteFile(fileTypesPath, []byte("// placeholder"), 0644)
+			if err != nil {
+				t.Fatalf("failed to write file_types.d.ts: %v", err)
+			}
+
+			// Create a mock logger
+			mockLog := &mockLogger{}
+
+			// Call the function under test
+			err = possiblyCreateDeclarationFile(mockLog, tmpDir)
+			if err != nil {
+				t.Fatalf("possiblyCreateDeclarationFile failed: %v", err)
+			}
+
+			// Read the result
+			result, err := os.ReadFile(indexPath)
+			if err != nil {
+				t.Fatalf("failed to read result file: %v", err)
+			}
+			
+
+
+			resultStr := string(result)
+			if resultStr != tt.expectedOutput {
+				t.Errorf("unexpected output\nexpected:\n%s\n\nactual:\n%s", tt.expectedOutput, resultStr)
+			}
+
+			// Verify import detection logic
+			hasImport := strings.Contains(resultStr, "import './file_types'") || strings.Contains(resultStr, "import \"./file_types\"")
+			if tt.shouldInsert && !hasImport {
+				t.Errorf("expected import to be inserted but it wasn't found")
+			}
+			if !tt.shouldInsert && hasImport && !strings.Contains(tt.inputContent, "file_types") {
+				t.Errorf("expected import not to be inserted but it was added")
+			}
+		})
+	}
+}
+
+func TestNeedsDeclarationUpdate(t *testing.T) {
+	tests := []struct {
+		name           string
+		fileContent    string
+		expectedHash   string
+		shouldUpdate   bool
+	}{
+		{
+			name:           "file doesn't exist",
+			fileContent:    "",
+			expectedHash:   "abc123",
+			shouldUpdate:   true,
+		},
+		{
+			name:           "file has matching hash",
+			fileContent:    "// agentuity-types-hash:abc123\ndeclare module '*.yml' {}",
+			expectedHash:   "abc123",
+			shouldUpdate:   false,
+		},
+		{
+			name:           "file has different hash",
+			fileContent:    "// agentuity-types-hash:def456\ndeclare module '*.yml' {}",
+			expectedHash:   "abc123",
+			shouldUpdate:   true,
+		},
+		{
+			name:           "file has no hash",
+			fileContent:    "declare module '*.yml' {}",
+			expectedHash:   "abc123",
+			shouldUpdate:   true,
+		},
+		{
+			name:           "empty file",
+			fileContent:    "",
+			expectedHash:   "abc123",
+			shouldUpdate:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "file doesn't exist" {
+				// Test non-existent file
+				result := needsDeclarationUpdate("/nonexistent/path", tt.expectedHash)
+				if result != tt.shouldUpdate {
+					t.Errorf("expected %v, got %v", tt.shouldUpdate, result)
+				}
+				return
+			}
+
+			// Create temporary file
+			tmpFile, err := os.CreateTemp("", "test_declaration")
+			if err != nil {
+				t.Fatalf("failed to create temp file: %v", err)
+			}
+			defer os.Remove(tmpFile.Name())
+
+			// Write test content
+			_, err = tmpFile.WriteString(tt.fileContent)
+			if err != nil {
+				t.Fatalf("failed to write test content: %v", err)
+			}
+			tmpFile.Close()
+
+			// Test the function
+			result := needsDeclarationUpdate(tmpFile.Name(), tt.expectedHash)
+			if result != tt.shouldUpdate {
+				t.Errorf("expected %v, got %v for content: %s", tt.shouldUpdate, result, tt.fileContent)
+			}
+		})
+	}
+}

--- a/internal/envutil/envutil_test.go
+++ b/internal/envutil/envutil_test.go
@@ -81,9 +81,9 @@ func TestIsAgentuityEnv(t *testing.T) {
 
 func TestShouldSyncToProduction(t *testing.T) {
 	tests := []struct {
-		name        string
-		isLocalDev  bool
-		shouldSync  bool
+		name       string
+		isLocalDev bool
+		shouldSync bool
 	}{
 		{
 			name:       "production mode should sync",


### PR DESCRIPTION
Example usage:


```
import ymldata from './test.yaml';
import jsondata from './test.json';
import agentuitypng from './agentuity.png';
import txt from './test.txt';
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import YAML, JSON, text, and common binary/image assets so they are bundled and exported for immediate use.
  * Automatic, idempotent creation/patching of a TypeScript declaration file before type checking to avoid missing-typing issues.

* **Chores**
  * Build now treats additional platform modules (e.g., bun, fsevents) as externals for improved compatibility.

* **Tests**
  * Added tests covering import insertion and declaration-hash update logic.
  * Minor whitespace/formatting cleanup in an existing test (no behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->