### PR TITLE
Onboard nudges on next steps. Changed shell completion failure from warn to ohai so it doesn't look like installation failed.

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -112,6 +112,7 @@ Examples:
 		tui.ClearScreen()
 		initScreenWithLogo()
 		tui.ShowSuccess("Welcome to Agentuity! You are now logged in")
+		showAuthNextSteps()
 	},
 }
 
@@ -219,6 +220,7 @@ Examples:
 		tui.ClearScreen()
 		initScreenWithLogo()
 		tui.ShowSuccess("Welcome to Agentuity! You are now logged in")
+		showAuthNextSteps()
 	},
 }
 

--- a/cmd/onboarding.go
+++ b/cmd/onboarding.go
@@ -1,0 +1,14 @@
+package cmd
+
+import "github.com/agentuity/go-common/tui"
+
+const onboardingDocsURL = "https://agentuity.dev/"
+
+func showAuthNextSteps() {
+	body := tui.Paragraph(
+		tui.Secondary("1. Run ")+tui.Command("create")+tui.Secondary(" to scaffold your first Agent project."),
+		tui.Secondary("2. Run ")+tui.Command("dev")+tui.Secondary(" to develop locally, then ")+tui.Command("deploy"),
+		tui.Secondary("3. Explore the docs, see samples, and more: ")+tui.Link("%s", onboardingDocsURL),
+	)
+	tui.ShowBanner("Keep building with Agentuity", body, false)
+}

--- a/install.sh
+++ b/install.sh
@@ -381,7 +381,7 @@ install_completions() {
             "$INSTALL_PATH/agentuity" completion bash > "$BASH_COMPLETION_DIR/agentuity"
             ohai "Bash completion installed to $BASH_COMPLETION_DIR/agentuity"
           else
-            warn "No write permission to $BASH_COMPLETION_DIR. Skipping bash completion installation."
+            ohai "No write permission to $BASH_COMPLETION_DIR. Skipping bash completion installation."
           fi
         fi
         
@@ -393,7 +393,7 @@ install_completions() {
             "$INSTALL_PATH/agentuity" completion zsh > "$ZSH_COMPLETION_DIR/_agentuity"
             ohai "Zsh completion installed to $ZSH_COMPLETION_DIR/_agentuity"
           else
-            warn "No write permission to $ZSH_COMPLETION_DIR. Skipping zsh completion installation."
+            ohai "No write permission to $ZSH_COMPLETION_DIR. Skipping zsh completion installation."
           fi
         elif ! command -v zsh >/dev/null 2>&1; then
           # Only skip silently if zsh is not installed (avoid unnecessary warnings)
@@ -409,7 +409,7 @@ install_completions() {
             "$INSTALL_PATH/agentuity" completion bash > "$BASH_COMPLETION_DIR/agentuity"
             ohai "Bash completion installed to $BASH_COMPLETION_DIR/agentuity"
           else
-            warn "No write permission to $BASH_COMPLETION_DIR. Skipping bash completion installation."
+            ohai "No write permission to $BASH_COMPLETION_DIR. Skipping bash completion installation."
             ohai "You can manually install bash completion with:"
             echo "  $INSTALL_PATH/agentuity completion bash > ~/.bash_completion"
           fi
@@ -423,7 +423,7 @@ install_completions() {
             "$INSTALL_PATH/agentuity" completion zsh > "$ZSH_COMPLETION_DIR/_agentuity"
             ohai "Zsh completion installed to $ZSH_COMPLETION_DIR/_agentuity"
           else
-            warn "No write permission to $ZSH_COMPLETION_DIR. Skipping zsh completion installation."
+            ohai "No write permission to $ZSH_COMPLETION_DIR. Skipping zsh completion installation."
             ohai "You can manually install zsh completion with:"
             echo "  mkdir -p ~/.zsh/completion"
             echo "  $INSTALL_PATH/agentuity completion zsh > ~/.zsh/completion/_agentuity"
@@ -439,9 +439,15 @@ install_completions() {
 }
 
 success() {
-  ohai "Installation complete! Run 'agentuity --help' to get started."
-  ohai "For more information, visit: $(url "https://agentuity.dev")"
-  
+  ohai "Installation complete!"
+  printf "%sNext steps:%s\n" "$tty_bold" "$tty_reset"
+  printf "  1. %sagentuity auth signup%s (or %sagentuity login%s if you already have an account)\n" "$tty_cyan" "$tty_reset" "$tty_cyan" "$tty_reset"
+  printf "  2. %sagentuity create%s to scaffold your first Agent project\n" "$tty_cyan" "$tty_reset"
+  printf "  3. %sagentuity dev%s to test locally, then %sagentuity deploy%s\n" "$tty_cyan" "$tty_reset" "$tty_cyan" "$tty_reset"
+  printf "  4. Explore the docs, see samples, and more: %s\n" "$(url "https://agentuity.dev/")"
+  printf "\n"
+  ohai "Need help? Run 'agentuity --help' anytime."
+
   if ! command -v agentuity >/dev/null 2>&1; then
     printf "${tty_blue}==>${tty_bold} ${tty_magenta}To apply PATH changes, restart your terminal or run:${tty_reset} source ~/.$(basename $SHELL 2>/dev/null)rc\n"
   fi


### PR DESCRIPTION
<img width="1621" height="575" alt="image" src="https://github.com/user-attachments/assets/e164c723-1e71-4fc1-bbda-c1767bcc8ea7" />

<img width="2036" height="931" alt="image" src="https://github.com/user-attachments/assets/0b29a314-cb71-4106-9397-9813c76cc358" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Displays an onboarding banner with next steps after successful login and signup.
* **Improvements**
  * Installer now provides clearer success messaging with actionable next steps and a help prompt (including a docs link).
  * Enhanced handling for zsh completions with graceful, non-fatal messaging when zsh or directories are unavailable.
  * More explicit confirmation when adding to PATH, including the displayed install location.
  * Refined wording throughout installation for a more positive, guided experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->